### PR TITLE
New node MipMap [Stride.Rendering] which allows to generate mipmaps

### DIFF
--- a/packages/VL.Stride.Runtime/src/Rendering/MipMapGenerator.cs
+++ b/packages/VL.Stride.Runtime/src/Rendering/MipMapGenerator.cs
@@ -1,0 +1,197 @@
+﻿// Much of this code is based on Stride's VideoTexture class.
+
+using Stride.Core;
+using Stride.Graphics;
+using Stride.Rendering;
+using System;
+using System.Collections.Generic;
+using VL.Core;
+using VL.Lib.Basics.Resources;
+using VL.Stride.Engine;
+
+namespace VL.Stride.Rendering
+{
+    /// <summary>
+    /// Generates a texture with the desired amount of mipmaps for a given input texture.
+    /// </summary>
+    class MipMapGenerator : global::Stride.Rendering.RendererBase
+    {
+        private readonly List<Texture> renderTargetMipMaps = new List<Texture>();
+        private readonly IResourceHandle<GraphicsDevice> graphicsDeviceHandle;
+        private readonly SchedulerSystem schedulerSystem;
+        private SamplerState minMagLinearMipPointSampler;
+        private EffectInstance effectTexture2DCopy;
+        private Texture inputTexture, outputTexture;
+        private int maxMipMapCount;
+
+        public MipMapGenerator(NodeContext nodeContext)
+        {
+            graphicsDeviceHandle = nodeContext.GetDeviceHandle().DisposeBy(this);
+            var gameHandle = nodeContext.GetGameHandle().DisposeBy(this);
+            schedulerSystem = gameHandle.Resource.Services.GetService<SchedulerSystem>();
+        }
+
+        /// <summary>
+        /// The input texture.
+        /// </summary>
+        public Texture InputTexture
+        {
+            get => inputTexture;
+            set
+            {
+                if (value != inputTexture)
+                {
+                    inputTexture = value;
+                    DeallocateOutput();
+                }
+            }
+        }
+
+        /// <summary>
+        /// The maximum amount of mipmaps to generate. Use zero to generate all.
+        /// </summary>
+        public int MaxMipMapCount
+        {
+            get => maxMipMapCount;
+            set
+            {
+                if (value != maxMipMapCount)
+                {
+                    maxMipMapCount = value;
+                    DeallocateOutput();
+                }
+            }
+        }
+
+        /// <summary>
+        /// The output texture with the generated mipmaps.
+        /// </summary>
+        public Texture OutputTexture
+        {
+            get => outputTexture ??= AllocateOutputTexture(InputTexture);
+        }
+
+        /// <summary>
+        /// Places this renderer in the rendering queue.
+        /// </summary>
+        public void ScheduleForRendering()
+        {
+            schedulerSystem.Schedule(this);
+        }
+
+        private Texture AllocateOutputTexture(Texture inputTexture)
+        {
+            if (inputTexture is null)
+                return null;
+
+            var width = inputTexture.Width;
+            var height = inputTexture.Height;
+
+            var mipMapCount = Texture.CountMips(Math.Max(width, height));
+            if (MaxMipMapCount > 0)
+                mipMapCount = Math.Min(mipMapCount, MaxMipMapCount);
+
+            var textureDescription = TextureDescription.New2D(width, height, mipMapCount, inputTexture.Format, TextureFlags.ShaderResource | TextureFlags.RenderTarget);
+            var renderTarget = Texture.New(graphicsDeviceHandle.Resource, textureDescription, null);
+            AllocateTextureViewsForMipMaps(renderTarget);
+            return renderTarget;
+        }
+
+        private void AllocateTextureViewsForMipMaps(Texture parentTexture)
+        {
+            DeallocateTextureViewsForMipMaps();
+
+            for (int i = 0; i < parentTexture.MipLevels; ++i)
+            {
+                var renderTargetMipMapTextureViewDescription = new TextureViewDescription
+                {
+                    Type = ViewType.Single,
+                    MipLevel = i,
+                    Format = parentTexture.Format,
+                    ArraySlice = 0,
+                    Flags = parentTexture.Flags,
+                };
+
+                Texture renderTargetMipMapTextureView = parentTexture.ToTextureView(renderTargetMipMapTextureViewDescription);
+                renderTargetMipMaps.Add(renderTargetMipMapTextureView);
+            }
+        }
+
+        private void DeallocateOutput()
+        {
+            DeallocateTextureViewsForMipMaps();
+            outputTexture?.Dispose();
+            outputTexture = null;
+        }
+
+        private void DeallocateTextureViewsForMipMaps()
+        {
+            foreach (var mipmap in renderTargetMipMaps)
+                mipmap.Dispose();
+
+            renderTargetMipMaps.Clear();
+        }
+
+        protected override void InitializeCore()
+        {
+            // We want to sample mip maps using point filtering (to make sure nothing bleeds between mip maps).
+            minMagLinearMipPointSampler = SamplerState.New(GraphicsDevice, new SamplerStateDescription(TextureFilter.MinMagLinearMipPoint, TextureAddressMode.Clamp))
+                .DisposeBy(this);
+
+            // Allocate the effect for copying regular 2d textures:
+            effectTexture2DCopy = new EffectInstance(EffectSystem.LoadEffect("SpriteEffectExtTextureRegular").WaitForResult())
+                .DisposeBy(this);
+            effectTexture2DCopy.Parameters.Set(SpriteEffectExtTextureRegularKeys.MipLevel, 0.0f);
+            effectTexture2DCopy.Parameters.Set(SpriteEffectExtTextureRegularKeys.Sampler, minMagLinearMipPointSampler);
+            effectTexture2DCopy.UpdateEffect(GraphicsDevice);
+
+            base.InitializeCore();
+        }
+
+        protected override void Destroy()
+        {
+            DeallocateOutput();
+            base.Destroy();
+        }
+
+        protected override void DrawCore(RenderDrawContext context)
+        {
+            if (InputTexture is null)
+                return;
+
+            var graphicsContext = context.GraphicsContext;
+
+            using (context.PushRenderTargetsAndRestore())
+            {
+                CopyTexture(graphicsContext,
+                            effectTexture2DCopy,
+                            InputTexture,
+                            renderTargetMipMaps[0]); // Set the highest mip map level as the render target.
+
+                // Generate mip maps (start from level 1 because we just generated  level 0 above):
+                for (int i = 1; i < renderTargetMipMaps.Count; ++i)
+                {
+                    CopyTexture(graphicsContext,
+                                effectTexture2DCopy,
+                                renderTargetMipMaps[i - 1], // Use the parent mip map level as the input texture.
+                                renderTargetMipMaps[i]); // Set the child mip map level as the render target.
+                }
+            }
+        }
+
+        private static void CopyTexture(GraphicsContext graphicsContext, EffectInstance effectInstance, Texture input, Texture output)
+        {
+            // Set the "input" texture as the texture that we will copy to "output":
+            effectInstance.Parameters.Set(SpriteEffectExtTextureRegularKeys.TextureRegular, input); // TODO: STABILITY: Supply the parent texture instead? I mean here we're using SampleLOD in the shader because texture views are basically being ignored during sampling on OpenGL/ES.
+
+            // Set the mipmap level of the input texture we want to sample:
+            effectInstance.Parameters.Set(SpriteEffectExtTextureRegularKeys.MipLevel, input.MipLevel);  // TODO: STABILITY: Manually pass the mip level?
+
+            // Set the "output" texture as the render target (the copy destination):
+            graphicsContext.CommandList.SetRenderTargetAndViewport(null, output);
+
+            // Perform the actual draw call to filter and copy the texture:
+            graphicsContext.DrawQuad(effectInstance);
+        }
+    }
+}

--- a/packages/VL.Stride.Runtime/src/Rendering/MipMapGenerator.cs
+++ b/packages/VL.Stride.Runtime/src/Rendering/MipMapGenerator.cs
@@ -87,7 +87,9 @@ namespace VL.Stride.Rendering
             var width = inputTexture.Width;
             var height = inputTexture.Height;
 
-            var mipMapCount = Texture.CountMips(Math.Max(width, height));
+            // Calculate the optimum amount of mip maps
+            var mipMapCount = Texture.CountMips(width, height);
+            // Clamp it to user maximum if provided
             if (MaxMipMapCount > 0)
                 mipMapCount = Math.Min(mipMapCount, MaxMipMapCount);
 

--- a/packages/VL.Stride.Runtime/src/Rendering/RenderingNodes.cs
+++ b/packages/VL.Stride.Runtime/src/Rendering/RenderingNodes.cs
@@ -63,11 +63,6 @@ namespace VL.Stride.Rendering
                 .AddOutput(nameof(GetWindowInputSource.InputSource), x => x.InputSource)
             ;
 
-            yield return factory.NewNode(c => new MipMapGenerator(c), name: "MipMap", category: renderingAdvancedCategory, copyOnWrite: false, fragmented: true, hasStateOutput: false)
-                .AddInput("Input", x => x.InputTexture, (x, v) => x.InputTexture = v)
-                .AddInput(nameof(MipMapGenerator.MaxMipMapCount), x => x.MaxMipMapCount, (x, v) => x.MaxMipMapCount = v)
-                .AddOutput("Output", x => { x.ScheduleForRendering(); return x.OutputTexture; });
-
             // Compute effect dispatchers
             var dispatchersCategory = $"{renderingAdvancedCategory}.ComputeEffect";
             yield return factory.NewNode<DirectComputeEffectDispatcher>(name: "DirectDispatcher", category: renderingAdvancedCategory, copyOnWrite: false, fragmented: true, hasStateOutput: false)
@@ -142,6 +137,11 @@ namespace VL.Stride.Rendering
                 .AddCachedInput(nameof(TorusProceduralModel.Tessellation), x => x.Tessellation, (x, v) => x.Tessellation = v, 16)
                 .AddDefaultPins();
 
+            // TextureFX
+            yield return factory.NewNode(c => new MipMapGenerator(c), name: "MipMap", category: "Stride.Textures.TextureFX", copyOnWrite: false, fragmented: true, hasStateOutput: false)
+                .AddInput("Input", x => x.InputTexture, (x, v) => x.InputTexture = v)
+                .AddInput(nameof(MipMapGenerator.MaxMipMapCount), x => x.MaxMipMapCount, (x, v) => x.MaxMipMapCount = v)
+                .AddOutput("Output", x => { x.ScheduleForRendering(); return x.OutputTexture; });
         }
 
         static CustomNodeDesc<TInputRenderBase> NewInputRenderBaseNode<TInputRenderBase>(IVLNodeDescriptionFactory factory, string category, string name = null)

--- a/packages/VL.Stride.Runtime/src/Rendering/RenderingNodes.cs
+++ b/packages/VL.Stride.Runtime/src/Rendering/RenderingNodes.cs
@@ -63,6 +63,11 @@ namespace VL.Stride.Rendering
                 .AddOutput(nameof(GetWindowInputSource.InputSource), x => x.InputSource)
             ;
 
+            yield return factory.NewNode(c => new MipMapGenerator(c), name: "MipMap", category: renderingAdvancedCategory, copyOnWrite: false, fragmented: true, hasStateOutput: false)
+                .AddInput("Input", x => x.InputTexture, (x, v) => x.InputTexture = v)
+                .AddInput(nameof(MipMapGenerator.MaxMipMapCount), x => x.MaxMipMapCount, (x, v) => x.MaxMipMapCount = v)
+                .AddOutput("Output", x => { x.ScheduleForRendering(); return x.OutputTexture; });
+
             // Compute effect dispatchers
             var dispatchersCategory = $"{renderingAdvancedCategory}.ComputeEffect";
             yield return factory.NewNode<DirectComputeEffectDispatcher>(name: "DirectDispatcher", category: renderingAdvancedCategory, copyOnWrite: false, fragmented: true, hasStateOutput: false)


### PR DESCRIPTION
The input texture is rendered multiple times in order to generate all mipmaps. It's the same technique as seen in the `VideoTexture` class of Stride. 

Related issues #215 and #369 

My main question is whether we're happy with the name/category (`MipMap [Stride.Rendering]`) of the node. Or should it be placed in the TextureFX category due to having in- and output texture?