### PR TITLE
PostFX usage simplified

### DIFF
--- a/packages/VL.Stride.Runtime/VL.Stride.Engine.vl
+++ b/packages/VL.Stride.Runtime/VL.Stride.Engine.vl
@@ -16403,18 +16403,22 @@
             <Patch Id="Dzu1Y5PJqfUOfNPHdFsLz7" Name="Create" />
             <Patch Id="PoJRbPFs2VGMZQCd9Yl8cf" Name="Update">
               <Pin Id="KGR1JmpfUR9PtP8doUTBlM" Name="Output" Kind="OutputPin" Bounds="328,450" />
-              <Pin Id="NkFc2JX9lDROOKsxqjJLdw" Name="Color Transforms" Kind="InputPin" />
+              <Pin Id="NkFc2JX9lDROOKsxqjJLdw" Name="Color Transforms" Kind="InputPin">
+                <p:TypeAnnotation>
+                  <Choice Kind="TypeFlag" Name="Spread" />
+                  <p:TypeArguments>
+                    <TypeReference>
+                      <Choice Kind="TypeFlag" Name="ColorTransform" />
+                    </TypeReference>
+                  </p:TypeArguments>
+                </p:TypeAnnotation>
+              </Pin>
               <Pin Id="NKGuHNrsupxQYkrWBUAXI0" Name="Enable Default ToneMap" Kind="InputPin" DefaultValue="True">
                 <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Boolean" />
                 </p:TypeAnnotation>
               </Pin>
             </Patch>
-            <!--
-
-    ************************  ************************
-
--->
             <ProcessDefinition Id="G0pmKoEvfGKOLu5tHdwn0c">
               <Fragment Id="IWk3ppOvujVLCnP1zOIEwM" Patch="Dzu1Y5PJqfUOfNPHdFsLz7" Enabled="true" />
               <Fragment Id="P97KCS3saGWObfq0kN4pLp" Patch="PoJRbPFs2VGMZQCd9Yl8cf" Enabled="true" />

--- a/packages/VL.Stride.Runtime/VL.Stride.Engine.vl
+++ b/packages/VL.Stride.Runtime/VL.Stride.Engine.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="UFzEbZy7D3GNY8xnLUU17p" LanguageVersion="2021.3.0.20" Version="0.128">
-  <NugetDependency Id="EKAeSpl0TUSO67sl9VuE19" Location="VL.CoreLib" Version="2021.3.0-0020-g2dbfb8d5b3" />
+<Document xmlns:p="property" Id="UFzEbZy7D3GNY8xnLUU17p" LanguageVersion="2021.3.0.42" Version="0.128">
+  <NugetDependency Id="EKAeSpl0TUSO67sl9VuE19" Location="VL.CoreLib" Version="2020.3.0-0092-gae02f44ee4" />
   <Patch Id="M3fVx2jjvOSLPGL4EJGFf9">
     <Canvas Id="JugVUmEZoitO7m1cCzT7W3" DefaultCategory="Stride" CanvasType="FullCategory">
       <Canvas Id="AM1t0H80MmiNL9vQcGuPCN" Name="Cameras" Position="253,169">
@@ -2736,10 +2736,6 @@
                     <Choice Kind="ProcessAppFlag" Name="TreeNodeParentManager" />
                     <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
                   </p:NodeReference>
-                  <Pin Id="LPrJE8AOOrZNqGEZQox4QY" Name="Node" Kind="InputPin" />
-                  <Pin Id="AK0VuHJ4bpEQTNI54pAnfS" Name="Output" Kind="OutputPin" />
-                  <Pin Id="KJVOZPkd20cQcNMJ5xW7j2" Name="Many Wanna Be Parents" Kind="OutputPin" />
-                  <Pin Id="UBs2CXvqU4uLhxq3SO90kN" Name="Toggle Warning" Kind="OutputPin" />
                   <Patch Id="IIKjBr2BL3NLeLrYd91wcV" Name="Attach To New Parent" ManuallySortedPins="true">
                     <Pin Id="IAqSuFFE1SDLC2yz8c5bIZ" Name="parent" Kind="InputPin" />
                     <Pin Id="MMB4kSoHRYwNgK93apG0Vg" Name="me" Kind="InputPin" />
@@ -2775,6 +2771,11 @@
                       <Pin Id="TDSesiGU5giNOqhs2rXKsw" Name="Output" Kind="StateOutputPin" />
                     </Node>
                   </Patch>
+                  <Pin Id="LPrJE8AOOrZNqGEZQox4QY" Name="Node" Kind="InputPin" />
+                  <Pin Id="VlONb1I5STKO5dRMmxOJFA" Name="Allow Multiple Connections To Same Parent" Kind="InputPin" />
+                  <Pin Id="AK0VuHJ4bpEQTNI54pAnfS" Name="Output" Kind="OutputPin" />
+                  <Pin Id="KJVOZPkd20cQcNMJ5xW7j2" Name="Many Wanna Be Parents" Kind="OutputPin" />
+                  <Pin Id="UBs2CXvqU4uLhxq3SO90kN" Name="Toggle Warning" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="446,733,25,19" Id="M9cck2uma9lM6bGOqcFquI">
                   <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
@@ -2879,10 +2880,6 @@
                     <Choice Kind="ProcessAppFlag" Name="TreeNodeParentManager" />
                     <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
                   </p:NodeReference>
-                  <Pin Id="PJJ8TZEC8rcL4K87XN76rb" Name="Node" Kind="InputPin" />
-                  <Pin Id="AoH09yLaftKPJmiKl5rftb" Name="Output" Kind="OutputPin" />
-                  <Pin Id="Mqw3ppaj4iIOq1sFvSJM6d" Name="Many Wanna Be Parents" Kind="OutputPin" />
-                  <Pin Id="Ovavusknv93MWJ2FelnGaz" Name="Toggle Warning" Kind="OutputPin" />
                   <Patch Id="BOPqTKTWvvuMrKqAtSadgO" Name="Attach To New Parent" ManuallySortedPins="true">
                     <ControlPoint Id="S40mqdRVVC0Nxt6dYnNTOh" Bounds="658,629" />
                     <ControlPoint Id="FlHrivzaduzMMDkRtuhhcw" Bounds="718,629" />
@@ -2988,6 +2985,11 @@
                       <Pin Id="Un1xGGv0NjNMNlXpbTL32m" Name="Result" Kind="OutputPin" />
                     </Node>
                   </Patch>
+                  <Pin Id="PJJ8TZEC8rcL4K87XN76rb" Name="Node" Kind="InputPin" />
+                  <Pin Id="P28lgCKrmE0LIVz57rvQrZ" Name="Allow Multiple Connections To Same Parent" Kind="InputPin" />
+                  <Pin Id="AoH09yLaftKPJmiKl5rftb" Name="Output" Kind="OutputPin" />
+                  <Pin Id="Mqw3ppaj4iIOq1sFvSJM6d" Name="Many Wanna Be Parents" Kind="OutputPin" />
+                  <Pin Id="Ovavusknv93MWJ2FelnGaz" Name="Toggle Warning" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="1075,879,65,19" Id="GLKGA3AnQI3La0f1uzebyr">
                   <p:NodeReference LastCategoryFullName="VL.Session" LastSymbolSource="VL.Lang.vl">
@@ -15831,7 +15833,7 @@
                 <Pin Id="IO3HuIYHKgeLhW2V6yqfZQ" Name="Bind Depth As Resource During Transparent Rendering" Kind="InputPin" />
                 <Pin Id="AgMr6VwuUpgL3Gs8g5AvDm" Name="Output" Kind="OutputPin" />
               </Node>
-              <Node Bounds="374,284,255,134" Id="TiOpPbcjTzgLRtz0kdIlW1">
+              <Node Bounds="374,284,211,91" Id="TiOpPbcjTzgLRtz0kdIlW1">
                 <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <Choice Kind="ApplicationStatefulRegion" Name="If" />
@@ -15839,32 +15841,26 @@
                 </p:NodeReference>
                 <Pin Id="URuKOIrK7GHLYqvC257ujm" Name="Condition" Kind="InputPin" />
                 <ControlPoint Id="K3hx0RJXx22K94zfdovyCG" Bounds="388,290" Alignment="Top" />
-                <ControlPoint Id="A623F5xPYfnPViPbrFhvHA" Bounds="388,412" Alignment="Bottom" />
+                <ControlPoint Id="A623F5xPYfnPViPbrFhvHA" Bounds="390,369" Alignment="Bottom" />
                 <Patch Id="JV98h5RqZEIPes3EkydRzH" ManuallySortedPins="true">
                   <Patch Id="SSv9OjDCDOQOEhv4gyPYiu" Name="Create" ManuallySortedPins="true" />
                   <Patch Id="I47SBrx7QMIQP1f8MxIC21" Name="Then" ManuallySortedPins="true" />
-                  <Node Bounds="386,364,165,19" Id="CSmogfsoFbGNI00g86iyzj">
-                    <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Rendering.Nodes">
-                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                      <Choice Kind="ProcessNode" Name="PostFX" />
-                    </p:NodeReference>
-                    <Pin Id="Q1tGP66cl3jP5ZAs5WlmF1" Name="Ambient Occlusion" Kind="InputPin" />
-                    <Pin Id="BYTY0lowiBjPDYln9CUlNT" Name="Local Reflections" Kind="InputPin" />
-                    <Pin Id="KEgAkTtrVHrL07F2zHVIHB" Name="Depth Of Field" Kind="InputPin" />
-                    <Pin Id="A9LPLK5lUvnLOMk5BkVmjN" Name="Bright Filter" Kind="InputPin" />
-                    <Pin Id="KVZC94hwQh3Li28kK5j5X7" Name="Bloom" Kind="InputPin" />
-                    <Pin Id="DcoqX2abHFrPvW8PC4XrJ2" Name="Light Streak" Kind="InputPin" />
-                    <Pin Id="PNVcF6dlR7ZNkDfGI5NU78" Name="Lens Flare" Kind="InputPin" />
-                    <Pin Id="OAZggHFuKIoPy2zdxbjCPL" Name="Color Transforms" Kind="InputPin" />
-                    <Pin Id="PIuo0cuizZaNrMnm2jFqfW" Name="Antialiasing" Kind="InputPin" />
-                    <Pin Id="AodimTnqx61POJGkYenkmp" Name="Output" Kind="OutputPin" />
-                  </Node>
-                  <Node Bounds="526,324,91,19" Id="Q5S4CLUb7olN5IpaypiDKO">
+                  <Node Bounds="388,320,185,19" Id="Pd6Y1CbpeWaLgCFCVIsXMu">
                     <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Engine.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                      <Choice Kind="ProcessAppFlag" Name="DefaultToneMap" />
+                      <Choice Kind="ProcessAppFlag" Name="PostFX" />
                     </p:NodeReference>
-                    <Pin Id="OiSPO1a7O1ROzY0ioo0gL8" Name="Result" Kind="OutputPin" />
+                    <Pin Id="Uow6gPLALZ9N54sjgrbdYV" Name="Color Transforms" Kind="InputPin" />
+                    <Pin Id="UTRS9iTqn46PQwfunKjqlv" Name="Enable Default ToneMap" Kind="InputPin" />
+                    <Pin Id="NI3xp9sYcDANe5D1Oy6Of6" Name="Ambient Occlusion" Kind="InputPin" />
+                    <Pin Id="HhiyQsW9rbcOquN4OTRaX1" Name="Local Reflections" Kind="InputPin" />
+                    <Pin Id="Dzi8AD0r7gXNRLLizTHOQL" Name="Depth Of Field" Kind="InputPin" />
+                    <Pin Id="NVMO7wGWjqYPojz1VpKrA9" Name="Bright Filter" Kind="InputPin" />
+                    <Pin Id="HDvaqTFOnnzNSg2uEGPeZT" Name="Bloom" Kind="InputPin" />
+                    <Pin Id="NqnbvdyAcEcQJFq3Rhy9Y0" Name="Light Streak" Kind="InputPin" />
+                    <Pin Id="J4iaPgrMEt6QUEzE4oNFRO" Name="Lens Flare" Kind="InputPin" />
+                    <Pin Id="JtryiqbDFeXNoTdXptFM5e" Name="Antialiasing" Kind="InputPin" />
+                    <Pin Id="OjRxCbxIGoROfjn2r6KwAu" Name="Output" Kind="OutputPin" />
                   </Node>
                 </Patch>
               </Node>
@@ -15958,7 +15954,6 @@
             </Patch>
             <Link Id="KqQuuyRj3FBMs7HwFR7rKl" Ids="ICWZJiPAWKQN3SHBhiVCQS,OhCfXJjfE1ENAVBRLWrGZ9" IsHidden="true" />
             <Link Id="EkXFVorx1KnOerz8mPxEBT" Ids="K3hx0RJXx22K94zfdovyCG,A623F5xPYfnPViPbrFhvHA" IsFeedback="true" />
-            <Link Id="P2d3XT4lEYsPEm0bRA2r4t" Ids="AodimTnqx61POJGkYenkmp,A623F5xPYfnPViPbrFhvHA" />
             <Link Id="O3wCiVAZcwZLRpef2tHgO2" Ids="OhCfXJjfE1ENAVBRLWrGZ9,K3hx0RJXx22K94zfdovyCG" />
             <Link Id="CyvuIdHT3JALsAl5XKwh1N" Ids="AgMr6VwuUpgL3Gs8g5AvDm,AmXJPMRvG9OQGHIxBfaKTx" />
             <Link Id="OPQViLU42BLLneyL3Cpv76" Ids="NPdIk77ONAvNDjydTz3VO4,FCh7tjKZDUlN8NQ943B6sH" />
@@ -15977,7 +15972,6 @@
             <Link Id="ItzGoeeUVWmLjctHQtAEb8" Ids="RoL0dSrbfD5PM1wg8oCez5,ADqig3nLjziPJb1CKnnMvp" IsHidden="true" />
             <Link Id="DOZezOm8iFCK9hoX58iiYS" Ids="ADqig3nLjziPJb1CKnnMvp,JQ8dVpVaYLkPLk0IvVGIF6" />
             <Link Id="BT4nWBkQzUHQQHigii86fQ" Ids="OhCfXJjfE1ENAVBRLWrGZ9,RUMjUVSnfUmNAXIAofzKUi" />
-            <Link Id="PDbMPKgaL7gQONOCI6wBf5" Ids="OiSPO1a7O1ROzY0ioo0gL8,OAZggHFuKIoPy2zdxbjCPL" />
             <Link Id="LzhvKKJQusRLvvKjxEQHmt" Ids="C7CeNu8ODWWOFtYY7848QB,URuKOIrK7GHLYqvC257ujm" />
             <Link Id="HmUKed5DsZ4NTIgFMeiN38" Ids="PLd10RuGr8BORSIfnVrxjx,RYwF67UN49oNYSHM6K6YN4" />
             <Link Id="CH6qVSipNReL7iMeOm8IH3" Ids="PMDS2c9u7c5P1MWG3K2F2m,QYGJOrp78c5NX3EbRsQcfW" />
@@ -16029,6 +16023,7 @@
               <Fragment Id="D6MlEgs5IK8QVWo3DfQGWr" Patch="GfwoIjoSKnePm6jk67l02N" Enabled="true" />
               <Fragment Id="Ca1hRVVyOJIO4Ocxi0CE01" Patch="JGp7hvDsT68LSPEbRiNJJa" Enabled="true" />
             </ProcessDefinition>
+            <Link Id="FAajoVG1xpAM3eunODl5YS" Ids="OjRxCbxIGoROfjn2r6KwAu,A623F5xPYfnPViPbrFhvHA" />
           </Patch>
         </Node>
         <!--
@@ -16310,7 +16305,7 @@
                 </Pin>
                 <Pin Id="Fba5YqLrpQtNyRhor5CH2q" Name="Output" Kind="OutputPin" />
               </Node>
-              <Node Bounds="476,329,65,19" Id="MOhlVvLe0gdNzwBgeb9Y6z">
+              <Node Bounds="414,354,65,19" Id="MOhlVvLe0gdNzwBgeb9Y6z">
                 <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="FromValue" />
@@ -16327,11 +16322,13 @@
                 <Pin Id="TxP6wqpZhiDPtXAQ5Rh0gh" Name="White Point" Kind="InputPin" />
                 <Pin Id="VPpsu2nU2khPfGoevZwocm" Name="Output" Kind="OutputPin" />
               </Node>
-              <ControlPoint Id="Lud2wqECGZsPDG6P3Bfb7m" Bounds="478,384" />
+              <ControlPoint Id="Lud2wqECGZsPDG6P3Bfb7m" Bounds="416,409" />
+              <ControlPoint Id="SYEArAPtmmzOwH9rLUvutJ" Bounds="552,408" />
             </Canvas>
             <Patch Id="UzVbqrDXjXWQZfikmNpCEM" Name="Create" />
             <Patch Id="NbLPLhkKqbKMc4M0B1G9cP" Name="Update">
-              <Pin Id="CvibLE746PUPdzvvMBzPMO" Name="Result" Kind="OutputPin" Bounds="480,384" />
+              <Pin Id="CvibLE746PUPdzvvMBzPMO" Name="Color Transforms" Kind="OutputPin" Bounds="480,384" />
+              <Pin Id="Tr66A5aSYpHMdrXTHYQjD0" Name="ToneMap" Kind="OutputPin" Bounds="401,380" />
             </Patch>
             <ProcessDefinition Id="MxBlrD5jcraPK8zMTM9m6H">
               <Fragment Id="B4Dy0jbAQwSO91CWe3R8tX" Patch="UzVbqrDXjXWQZfikmNpCEM" Enabled="true" />
@@ -16341,6 +16338,143 @@
             <Link Id="OeTxBIsyZpKNfTksg9bzi1" Ids="VPpsu2nU2khPfGoevZwocm,AFbPSUkdyr6NJqIRK6bJWJ" />
             <Link Id="UHOCqKcs3kONknYGuhqCRF" Ids="S7aqXi6J3jTPGcS9sv0ulA,Lud2wqECGZsPDG6P3Bfb7m" />
             <Link Id="JHMMJgKUru9PyPwVusK3it" Ids="Lud2wqECGZsPDG6P3Bfb7m,CvibLE746PUPdzvvMBzPMO" IsHidden="true" />
+            <Link Id="PrkGlsgFlVNNGIkLox95uk" Ids="Fba5YqLrpQtNyRhor5CH2q,SYEArAPtmmzOwH9rLUvutJ" />
+            <Link Id="Geq2igwoc4OLhMmGWpUk4P" Ids="SYEArAPtmmzOwH9rLUvutJ,Tr66A5aSYpHMdrXTHYQjD0" IsHidden="true" />
+          </Patch>
+        </Node>
+        <!--
+
+    ************************ PostFX ************************
+
+-->
+        <Node Name="PostFX" Bounds="294,479" Id="USLjXEUVWW8MczagW9Rhxy">
+          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <Choice Kind="ContainerDefinition" Name="Process" />
+          </p:NodeReference>
+          <Patch Id="UT8OP0YAmxOOsR2LlBhEGd">
+            <Canvas Id="VPkYK2YHgLVLDcZoAEaEVP" CanvasType="Group">
+              <Node Bounds="514,527,165,19" Id="Rs3BooMlRcfLTzEQgkGTSK">
+                <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Rendering.Nodes">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessNode" Name="PostFXCore" />
+                </p:NodeReference>
+                <Pin Id="O9RyB1tvzCGLBpLgQ0OWA3" Name="Ambient Occlusion" Kind="InputPin" />
+                <Pin Id="LBglYTOWBQPLTbyUXWR6Hm" Name="Local Reflections" Kind="InputPin" />
+                <Pin Id="SHWHF8uCHt8L3jqV0CVhV9" Name="Depth Of Field" Kind="InputPin" />
+                <Pin Id="GsKdAJ1A4HAOPOiTO7nYdN" Name="Bright Filter" Kind="InputPin" />
+                <Pin Id="Trfuz39sfaxNJxp3nanVfO" Name="Bloom" Kind="InputPin" />
+                <Pin Id="QquW5r3t5SlNDyiWGjmCMv" Name="Light Streak" Kind="InputPin" />
+                <Pin Id="KNMfOXEXi6KM1t3WIEAoFn" Name="Lens Flare" Kind="InputPin" />
+                <Pin Id="IgSbqQSBrKWO3fFhrKgtnd" Name="Color Transforms" Kind="InputPin" />
+                <Pin Id="L9UnprVx8hvPSmVqNoJG06" Name="Antialiasing" Kind="InputPin" />
+                <Pin Id="AeTEVvYj0oAQDQFTeUJUXw" Name="Output" Kind="OutputPin" />
+              </Node>
+              <ControlPoint Id="LDiroPy4II2P8AjVMYBiHw" Bounds="516,600" />
+              <ControlPoint Id="OBNy9GTNAxkPFzixPHtXos" Bounds="44,123" />
+              <ControlPoint Id="ESZh4tGyWFQNXDyMEpvWuw" Bounds="170,123" />
+              <ControlPoint Id="VHf48arBgSHMaBMFRWJqXs" Bounds="266,123" />
+              <ControlPoint Id="GAjwGnHvil4OXnhiaflRZc" Bounds="362,123" />
+              <ControlPoint Id="RmlojKtgjOONwr3lHuUrGm" Bounds="458,123" />
+              <ControlPoint Id="DHl8WOMnSXsP5Dw0TvU83N" Bounds="524,123" />
+              <ControlPoint Id="HHmw18LFseNNzBYgZYNQzG" Bounds="620,123" />
+              <ControlPoint Id="DsFQYIH8WWOPptwDRQq4hw" Bounds="700,123" />
+              <ControlPoint Id="LQp3wnruREyMC158Q3DfWB" Bounds="812,123" />
+              <ControlPoint Id="VbkqgobEamiNTNojFQHCcj" Bounds="975,123" />
+              <Node Bounds="705,297,45,26" Id="FwsYPBupeCYNZw9B1ENVhG">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="Add" />
+                  <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
+                </p:NodeReference>
+                <Pin Id="KGEbgGu5GFiO6BpKBpWfPC" Name="Input" Kind="StateInputPin" />
+                <Pin Id="CyIjwTqmyH5OyhT9X6eakS" Name="Item" Kind="InputPin" />
+                <Pin Id="M2ItsVHiO0yLbdh6UA6k6o" Name="Output" Kind="StateOutputPin" />
+                <Pin Id="J799UYHxQ4KNAiuiUkfYQd" Name="Apply" Kind="InputPin" />
+              </Node>
+              <Node Bounds="641,228,91,19" Id="Rw51xuLJlFZOqdMqWVYRQe">
+                <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Engine.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="DefaultToneMap" />
+                </p:NodeReference>
+                <Pin Id="Ut9BecQdZaDOaRXrOKZz3W" Name="Color Transforms" Kind="OutputPin" />
+                <Pin Id="HxTmNSdokdaOwrbfM7PfHV" Name="ToneMap" Kind="OutputPin" />
+              </Node>
+            </Canvas>
+            <Patch Id="Dzu1Y5PJqfUOfNPHdFsLz7" Name="Create" />
+            <Patch Id="PoJRbPFs2VGMZQCd9Yl8cf" Name="Update">
+              <Pin Id="KGR1JmpfUR9PtP8doUTBlM" Name="Output" Kind="OutputPin" Bounds="328,450" />
+              <Pin Id="NkFc2JX9lDROOKsxqjJLdw" Name="Color Transforms" Kind="InputPin" />
+              <Pin Id="NKGuHNrsupxQYkrWBUAXI0" Name="Enable Default ToneMap" Kind="InputPin" DefaultValue="True">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <Choice Kind="TypeFlag" Name="Boolean" />
+                </p:TypeAnnotation>
+              </Pin>
+            </Patch>
+            <!--
+
+    ************************  ************************
+
+-->
+            <ProcessDefinition Id="G0pmKoEvfGKOLu5tHdwn0c">
+              <Fragment Id="IWk3ppOvujVLCnP1zOIEwM" Patch="Dzu1Y5PJqfUOfNPHdFsLz7" Enabled="true" />
+              <Fragment Id="P97KCS3saGWObfq0kN4pLp" Patch="PoJRbPFs2VGMZQCd9Yl8cf" Enabled="true" />
+              <Fragment Id="BrMmsr8aJndPFqIwLDGjUB" Patch="KGiMRHQj0I5QDNfiAVUoyo" Enabled="true" />
+              <Fragment Id="CxlEHjrdmzyOZIIECDX5yL" Patch="Bog8WNzHbc0MenX80YXekI" Enabled="true" />
+              <Fragment Id="Tvz8tD7WfYVPo9fWkBQElc" Patch="BvyjskTXAssP1UYA2mW1yc" Enabled="true" />
+              <Fragment Id="GAyWabeG7CSN3LXnnsMngF" Patch="QWEFYkstfrIQJt6evyJHLY" Enabled="true" />
+              <Fragment Id="UxS3sIi5ysAP53BrTAvkTO" Patch="PzYOvOFcOnoO6oKmzuKHqz" Enabled="true" />
+              <Fragment Id="LvTybzKL5XsPn6MZrVoaE7" Patch="AP5BWxAH7ftMZpc10WtEEV" Enabled="true" />
+              <Fragment Id="Na77sZs9jKfOW3iqO0amOb" Patch="GhMUn78X51tMpnkeP9zVZg" Enabled="true" />
+              <Fragment Id="ICRBZ2ny2GYQdszQs8k6EE" Patch="Mjd1zjvklAGLEJ9k5rOsEy" Enabled="true" />
+            </ProcessDefinition>
+            <Link Id="UGw3D9JunxVOVPvjq8nuZJ" Ids="AeTEVvYj0oAQDQFTeUJUXw,LDiroPy4II2P8AjVMYBiHw" />
+            <Link Id="DDng9aiCyarPBYiF9fijy4" Ids="LDiroPy4II2P8AjVMYBiHw,KGR1JmpfUR9PtP8doUTBlM" IsHidden="true" />
+            <Link Id="FqNG8a5fKsfMnyFaFQPbkF" Ids="OBNy9GTNAxkPFzixPHtXos,O9RyB1tvzCGLBpLgQ0OWA3" />
+            <Link Id="Er5NkCl6hYuQLMhLqHpyCk" Ids="S5atPDJS8SVOKLjKCeL3a1,OBNy9GTNAxkPFzixPHtXos" IsHidden="true" />
+            <Link Id="RPfTIllx6wSN9F2ou49vDg" Ids="ESZh4tGyWFQNXDyMEpvWuw,LBglYTOWBQPLTbyUXWR6Hm" />
+            <Link Id="COGM8WTZB4NMwuu83gmlsT" Ids="HrP9ZxK0olQQO97bt7QXmz,ESZh4tGyWFQNXDyMEpvWuw" IsHidden="true" />
+            <Link Id="CppjRArKnvrNxU2vHzkauZ" Ids="VHf48arBgSHMaBMFRWJqXs,SHWHF8uCHt8L3jqV0CVhV9" />
+            <Link Id="Dp0vzGV0zaALtQBDF4Kj5j" Ids="TTljS6HWzcwM7MMbiEsOMg,VHf48arBgSHMaBMFRWJqXs" IsHidden="true" />
+            <Link Id="Tv9Z1mzIARyLmixjPB71mm" Ids="GAjwGnHvil4OXnhiaflRZc,GsKdAJ1A4HAOPOiTO7nYdN" />
+            <Link Id="RYicziOYLnOP3mHdOjrlBq" Ids="BEgXRTQygINN2YxXByqCvk,GAjwGnHvil4OXnhiaflRZc" IsHidden="true" />
+            <Link Id="RTQr0BRe7oyPw8i1OgDPIW" Ids="RmlojKtgjOONwr3lHuUrGm,Trfuz39sfaxNJxp3nanVfO" />
+            <Link Id="Fp9H81PymrDNrNzlLofZgo" Ids="ESAfSvqyLYbP0Tp6EZalM2,RmlojKtgjOONwr3lHuUrGm" IsHidden="true" />
+            <Link Id="TdFhUabedsuMZQMJqWKjbu" Ids="DHl8WOMnSXsP5Dw0TvU83N,QquW5r3t5SlNDyiWGjmCMv" />
+            <Link Id="FCm9DzaribQNNM2Tmmy7Zq" Ids="Vn2Q3Ar9zD4MCjd3Uykr9x,DHl8WOMnSXsP5Dw0TvU83N" IsHidden="true" />
+            <Link Id="C4GzwTvkfozOXrdFhHByWR" Ids="U8OwX2UnnryNp5ejMasobk,HHmw18LFseNNzBYgZYNQzG" IsHidden="true" />
+            <Link Id="FCWfZQ9C7HrPWl8X9tDexu" Ids="NkFc2JX9lDROOKsxqjJLdw,DsFQYIH8WWOPptwDRQq4hw" IsHidden="true" />
+            <Link Id="HHbXF0SUArjMuEUufJ9tD6" Ids="HHmw18LFseNNzBYgZYNQzG,KNMfOXEXi6KM1t3WIEAoFn" />
+            <Link Id="Js1XI3h7wwLK98nhO7kQEX" Ids="NKGuHNrsupxQYkrWBUAXI0,LQp3wnruREyMC158Q3DfWB" IsHidden="true" />
+            <Link Id="MwvaSr6HQSiLGlUkVHAA09" Ids="VbkqgobEamiNTNojFQHCcj,L9UnprVx8hvPSmVqNoJG06" />
+            <Link Id="LABviLb1wUOOuJDuSYpPR5" Ids="SJSO3rhjwhrPGoLeeHKhO3,VbkqgobEamiNTNojFQHCcj" IsHidden="true" />
+            <Patch Id="KGiMRHQj0I5QDNfiAVUoyo" Name="SetAmbientOcclusion">
+              <Pin Id="S5atPDJS8SVOKLjKCeL3a1" Name="Ambient Occlusion" Kind="InputPin" />
+            </Patch>
+            <Patch Id="Bog8WNzHbc0MenX80YXekI" Name="SetLocalReflections">
+              <Pin Id="HrP9ZxK0olQQO97bt7QXmz" Name="Local Reflections" Kind="InputPin" />
+            </Patch>
+            <Patch Id="BvyjskTXAssP1UYA2mW1yc" Name="SetDepthOfField">
+              <Pin Id="TTljS6HWzcwM7MMbiEsOMg" Name="Depth Of Field" Kind="InputPin" />
+            </Patch>
+            <Patch Id="QWEFYkstfrIQJt6evyJHLY" Name="SetBrightFilter">
+              <Pin Id="BEgXRTQygINN2YxXByqCvk" Name="Bright Filter" Kind="InputPin" />
+            </Patch>
+            <Patch Id="PzYOvOFcOnoO6oKmzuKHqz" Name="SetBloom">
+              <Pin Id="ESAfSvqyLYbP0Tp6EZalM2" Name="Bloom" Kind="InputPin" />
+            </Patch>
+            <Patch Id="AP5BWxAH7ftMZpc10WtEEV" Name="SetLightStreak">
+              <Pin Id="Vn2Q3Ar9zD4MCjd3Uykr9x" Name="Light Streak" Kind="InputPin" />
+            </Patch>
+            <Patch Id="GhMUn78X51tMpnkeP9zVZg" Name="SetLensFlare">
+              <Pin Id="U8OwX2UnnryNp5ejMasobk" Name="Lens Flare" Kind="InputPin" />
+            </Patch>
+            <Patch Id="Mjd1zjvklAGLEJ9k5rOsEy" Name="SetAntialiasing">
+              <Pin Id="SJSO3rhjwhrPGoLeeHKhO3" Name="Antialiasing" Kind="InputPin" />
+            </Patch>
+            <Link Id="BRkMJFFA8WROwBVzC54QHi" Ids="DsFQYIH8WWOPptwDRQq4hw,KGEbgGu5GFiO6BpKBpWfPC" />
+            <Link Id="AtAIR5oSbsiOxSCrv1t1HZ" Ids="M2ItsVHiO0yLbdh6UA6k6o,IgSbqQSBrKWO3fFhrKgtnd" />
+            <Link Id="CSGLHQuy3s6LrBW6xfCyp1" Ids="LQp3wnruREyMC158Q3DfWB,J799UYHxQ4KNAiuiUkfYQd" />
+            <Link Id="RS51UyIg24dMNj9dIlZnJ4" Ids="HxTmNSdokdaOwrbfM7PfHV,CyIjwTqmyH5OyhT9X6eakS" />
           </Patch>
         </Node>
       </Canvas>
@@ -22634,8 +22768,8 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="NPPs0gHWhhDLwbJWw9C5Qt" Location="VL.Core" Version="2021.3.0-0020-g2dbfb8d5b3" />
-  <NugetDependency Id="DpOkG08YmwMOrERTyWIWIl" Location="VL.EditingFramework" Version="2021.3.0-0020-g2dbfb8d5b3" />
+  <NugetDependency Id="NPPs0gHWhhDLwbJWw9C5Qt" Location="VL.Core" Version="2020.3.0-0092-gae02f44ee4" />
+  <NugetDependency Id="DpOkG08YmwMOrERTyWIWIl" Location="VL.EditingFramework" Version="2020.3.0-0092-gae02f44ee4" />
   <PlatformDependency Id="OPlGizMUnBvPvn5XHsJ8EW" Location="./src/bin/Debug/netstandard2.0/VL.Stride.Runtime.dll" />
   <PlatformDependency Id="PNVK9A76J93L79pFuBD4B3" Location="../TestGame/Bin/Windows/Debug/Stride.Games.dll" />
   <PlatformDependency Id="Lg8KGAfsRcwOnEfRhBsBQG" Location="../TestGame/Bin/Windows/Debug/Stride.Engine.dll" />
@@ -22643,7 +22777,7 @@
   <DocumentDependency Id="I9kZBuopBpePX7pwvio3o3" Location="./VL.Stride.Input.vl" />
   <DocumentDependency Id="IDoNCTKSzHfQQlS52M4MXv" Location="./VL.Stride.Rendering.vl" IsFriend="true" />
   <PlatformDependency Id="H2f8MXufRYpPuRjIjOK3q3" Location="../TestGame/Bin/Windows/Debug/Stride.Core.Mathematics.dll" />
-  <NugetDependency Id="IHEIDRov8LFO2eD48F4Hs0" Location="VL.Lang" Version="2021.3.0-0020-g2dbfb8d5b3" />
+  <NugetDependency Id="IHEIDRov8LFO2eD48F4Hs0" Location="VL.Lang" Version="2020.3.0-0092-gae02f44ee4" />
   <DocumentDependency Id="GILZwUe2iGgPKA8BP1W5y0" Location="./VL.Stride.Games.vl" />
   <DocumentDependency Id="GWdYb2ByA41MUfWOOserWC" Location="./VL.Stride.Rendering.Instancer.vl" />
   <DocumentDependency Id="LWxCxaUoeDdLDEIgLy5CeO" Location="./VL.Stride.Graphics.vl" />

--- a/packages/VL.Stride.Runtime/help/Materials/Example Layers - Day and Night Earth.vl
+++ b/packages/VL.Stride.Runtime/help/Materials/Example Layers - Day and Night Earth.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="QMvcVCaHXKaNulOK0b1uV7" LanguageVersion="2020.3.0.72" Version="0.128">
-  <NugetDependency Id="JejpotU3dSXPXs5XjH80wB" Location="VL.CoreLib" Version="2020.3.0-0072-g169e836da4" />
+<Document xmlns:p="property" Id="QMvcVCaHXKaNulOK0b1uV7" LanguageVersion="2021.3.0.42" Version="0.128">
+  <NugetDependency Id="JejpotU3dSXPXs5XjH80wB" Location="VL.CoreLib" Version="2020.3.0-0092-gae02f44ee4" />
   <Patch Id="SN7eNt5lZgXLoudsI4KEdV">
     <Canvas Id="KBa5O7MmcfrPZUFc8kMF1J" DefaultCategory="Main" CanvasType="FullCategory">
       <!--
@@ -174,7 +174,7 @@
                     </p:TypeAnnotation>
                   </Pad>
                   <Node Bounds="633,440,65,19" Id="JlYZlMI0FttOXd9lsTbABH">
-                    <p:NodeReference LastCategoryFullName="Stride.Materials.TextureMaps" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Materials.Inputs" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="ColorMap" />
                     </p:NodeReference>
@@ -189,7 +189,7 @@
                     <Pin Id="AKalab8E4uIOCM5pIVDXyO" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="467,449,65,19" Id="J8IXDoCjQPhMvUMEiKIDmo">
-                    <p:NodeReference LastCategoryFullName="Stride.Materials.TextureMaps" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Materials.Inputs" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="ValueMap" />
                     </p:NodeReference>
@@ -321,7 +321,7 @@
                     </p:TypeAnnotation>
                   </Pad>
                   <Node Bounds="533,389,65,19" Id="GmuLtOD6kqoQME9wC7Q1zx">
-                    <p:NodeReference LastCategoryFullName="Stride.Materials.TextureMaps" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Materials.Inputs" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="ColorMap" />
                     </p:NodeReference>
@@ -474,7 +474,7 @@
                   <ControlPoint Id="LRgCkmyWPy4MGO4FX45FXA" Bounds="760,166" />
                   <ControlPoint Id="OaNDYWgIoRCN3yR1blOZbI" Bounds="521,677" />
                   <Node Bounds="519,568,105,19" Id="APzI1gH1ewpO8Su0y0BdYn">
-                    <p:NodeReference LastCategoryFullName="Stride.Materials.TextureMaps" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl">
+                    <p:NodeReference LastCategoryFullName="Stride.Materials.Inputs" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="ValueMap" />
                     </p:NodeReference>
@@ -627,10 +627,12 @@
         <Patch Id="VEdIWTVa11FM7z3sbFu39Q">
           <Canvas Id="VZHgFlkUIL9PPK4E1QYJ01" CanvasType="Group">
             <Node Bounds="432,419,165,19" Id="U5Vg6RkrXfgOTx1448sgRt">
-              <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Rendering.Nodes">
+              <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Engine.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessNode" Name="PostFX" />
               </p:NodeReference>
+              <Pin Id="E1JLcaE0wTVOmbkklUXV7z" Name="Color Transforms" Kind="InputPin" />
+              <Pin Id="Gm7Kx9UObWZNWmdLZnDUz0" Name="Enable Default ToneMap" Kind="InputPin" />
               <Pin Id="OlTMmyww0oKN4sjPMbvWHm" Name="Ambient Occlusion" Kind="InputPin" />
               <Pin Id="LrJUlPWZFFLL0jYCVAIvpK" Name="Local Reflections" Kind="InputPin" />
               <Pin Id="EXqlu4aek1xOP662SB7WsB" Name="Depth Of Field" Kind="InputPin" />
@@ -638,7 +640,6 @@
               <Pin Id="HjdH0YtY7cALezgOxYD3jQ" Name="Bloom" Kind="InputPin" />
               <Pin Id="BDyEp3RAR4HN6Lb7NtC7sg" Name="Light Streak" Kind="InputPin" />
               <Pin Id="VnFT3qXrYwoOclNil7XlVN" Name="Lens Flare" Kind="InputPin" />
-              <Pin Id="E1JLcaE0wTVOmbkklUXV7z" Name="Color Transforms" Kind="InputPin" />
               <Pin Id="LgktXKQWSPNOAcwYxKznZG" Name="Antialiasing" Kind="InputPin" />
               <Pin Id="Dxtz1wmZk7dO8dVlcNwBHW" Name="Output" Kind="OutputPin" />
             </Node>
@@ -708,13 +709,6 @@
               <Pin Id="OdvgXw1AlbbPSmsSnpl6HO" Name="Enabled" Kind="InputPin" />
               <Pin Id="BDHN4omPV35MEURHdX1BXe" Name="Output" Kind="OutputPin" />
             </Node>
-            <Node Bounds="839,358,91,19" Id="Fv6RAwHr80rPLcPTJ8hzRk">
-              <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Engine.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="DefaultToneMap" />
-              </p:NodeReference>
-              <Pin Id="EppKX15taGiL8LjIHGPn8B" Name="Result" Kind="OutputPin" />
-            </Node>
             <ControlPoint Id="ND5WCkqdqk0LLPIrjC7M5X" Bounds="434,461" />
             <Pad Id="Q52o700pqSMPymuKgAgfem" Comment="Intensity" Bounds="338,332,35,15" ShowValueBox="true" isIOBox="true" Value="1">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
@@ -734,7 +728,6 @@
           <Link Id="JxdJHNFbqnPPU22DCT0Q4l" Ids="M26oiJtkGloNWjYp1uQ7Ie,HjdH0YtY7cALezgOxYD3jQ" />
           <Link Id="MEM9TVsjR0lNet659OCw3R" Ids="MjTrCMZ4TCzLtv3Nq2BLeH,BDyEp3RAR4HN6Lb7NtC7sg" />
           <Link Id="NvmIgbMxZpjMxHB00AVRZk" Ids="BDHN4omPV35MEURHdX1BXe,OlTMmyww0oKN4sjPMbvWHm" />
-          <Link Id="BRS6snPy2H8PLK5iLauXcm" Ids="EppKX15taGiL8LjIHGPn8B,E1JLcaE0wTVOmbkklUXV7z" />
           <Link Id="Gi4diagkvtNMvxmzOP2L2P" Ids="Dxtz1wmZk7dO8dVlcNwBHW,ND5WCkqdqk0LLPIrjC7M5X" />
           <Link Id="LgHiSC1Dr2IMjSKR9ZhetQ" Ids="ND5WCkqdqk0LLPIrjC7M5X,IWXvJzISqJgOtIyeATGXs7" IsHidden="true" />
           <Link Id="IL9TyljvaDOPb6lYnvNNIw" Ids="Q52o700pqSMPymuKgAgfem,H6QW4f8RoBQPhwc8RxeeQ9" />
@@ -754,7 +747,7 @@
       <Patch Id="Dq4OJO8qSUxOPBbvl8nBxX">
         <Canvas Id="O3NJsHquUAtNBDEr3KjMVJ" CanvasType="Group">
           <Node Bounds="409,627,225,19" Id="Dg8JyjG6IMSNdaZmIDdDwP">
-            <p:NodeReference LastCategoryFullName="Stride" LastSymbolSource="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride" LastSymbolSource="VL.Stride.Engine.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SceneWindow" />
             </p:NodeReference>
@@ -813,6 +806,7 @@
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
+            <Pin Id="C4gkfWnDUCdMU6zkOE4usQ" Name="Force Build" Kind="InputPin" />
             <Pin Id="GchvOuHNcz6OKD1xWWZNNw" Name="Background Intensity" Kind="InputPin" />
             <Pin Id="EHav5eQ6bsHPG0bgPdns9Q" Name="Background Enabled" Kind="InputPin" DefaultValue="False">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
@@ -986,6 +980,6 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="SccdtefP4cpOKEx3VhzltZ" Location="VL.Stride" Version="0.8.87-g05eef96666" />
-  <NugetDependency Id="E3EZhvDPEwHO6FnOqhjBBs" Location="VL.Skia" Version="2020.3.0-0072-g169e836da4" />
+  <NugetDependency Id="SccdtefP4cpOKEx3VhzltZ" Location="VL.Stride" Version="0.9.53-gf91822d3de" />
+  <NugetDependency Id="E3EZhvDPEwHO6FnOqhjBBs" Location="VL.Skia" Version="2020.3.0-0092-gae02f44ee4" />
 </Document>

--- a/packages/VL.Stride.Runtime/help/Overview/HowTo Work with Children.vl
+++ b/packages/VL.Stride.Runtime/help/Overview/HowTo Work with Children.vl
@@ -776,10 +776,16 @@
             <Pin Id="E3YY2ItyQZ6LzsxIuF17EV" Name="Result" Kind="OutputPin" />
           </Node>
           <Node Bounds="645,1078,165,19" Id="HYagi4NjWwaQGLVjCEXI6u">
-            <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Rendering.Nodes">
+            <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Engine.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessNode" Name="PostFX" />
             </p:NodeReference>
+            <Pin Id="GnSIApbHcObNqpVq7MM8iw" Name="Color Transforms" Kind="InputPin" />
+            <Pin Id="UJkcnbBACX6L2rO40t7eH9" Name="Enable Default ToneMap" Kind="InputPin" DefaultValue="True">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="Boolean" />
+              </p:TypeAnnotation>
+            </Pin>
             <Pin Id="PEpoifn6FDyL5knkvuaYC6" Name="Ambient Occlusion" Kind="InputPin" />
             <Pin Id="BjZLERfUxYFQDPYHr3pdHK" Name="Local Reflections" Kind="InputPin" />
             <Pin Id="E8VkdQDiiebNEkcSDvKXeg" Name="Depth Of Field" Kind="InputPin" />
@@ -787,7 +793,6 @@
             <Pin Id="E1TsUTgVENaPfI6jz7Jh7V" Name="Bloom" Kind="InputPin" />
             <Pin Id="AEBgbdj3eqKMHdRwjbi1Uh" Name="Light Streak" Kind="InputPin" />
             <Pin Id="SuPpUKShbvnLn1jI5p0dqu" Name="Lens Flare" Kind="InputPin" />
-            <Pin Id="GnSIApbHcObNqpVq7MM8iw" Name="Color Transforms" Kind="InputPin" />
             <Pin Id="HWYpPccvQdBNl2RQXYpzws" Name="Antialiasing" Kind="InputPin" />
             <Pin Id="NDklh8g9HkZMV6OgSS8gFe" Name="Output" Kind="OutputPin" />
           </Node>
@@ -825,13 +830,6 @@
             <Pin Id="ECVjDyaSXgWOBXVMt6PAcJ" Name="Halo" Kind="InputPin" />
             <Pin Id="GdAtShjrUZyN4thgF8yN8U" Name="Enabled" Kind="InputPin" />
             <Pin Id="K48Ts8Xv7zGODPf8lnNdHq" Name="Output" Kind="OutputPin" />
-          </Node>
-          <Node Bounds="848,970,91,19" Id="R30WLxYyTm9O1mrnLew6tt">
-            <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Engine.vl">
-              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-              <Choice Kind="ProcessAppFlag" Name="DefaultToneMap" />
-            </p:NodeReference>
-            <Pin Id="RKkEeapatvtQSQ16w2qZMI" Name="Result" Kind="OutputPin" />
           </Node>
           <Pad Id="TCEBzKvTg7tPdrYT8fR3eO" Comment="Power" Bounds="404,815,35,15" ShowValueBox="true" isIOBox="true" Value="1.71">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
@@ -894,11 +892,10 @@
         <Link Id="KUneiO5kJtPOkzQBa273rU" Ids="M1k23mVjBEUNfR2v0yHx4v,SKB4Z43gAGpN1vY43lRNzj" />
         <Link Id="MbntfGSiNe6Qbpf2vh7oPD" Ids="E3YY2ItyQZ6LzsxIuF17EV,F8ywtKxphxWPD5mI9FtciK" />
         <Link Id="JG4D4TFuOhMLjaETGYQp00" Ids="E3YY2ItyQZ6LzsxIuF17EV,SyrSQdZ1B1oNBL1hyLKo8w" />
-        <Link Id="GHXE5TdYVpQL9anYSpK1No" Ids="RKkEeapatvtQSQ16w2qZMI,GnSIApbHcObNqpVq7MM8iw" />
-        <Link Id="SlFY3IBnvlDPcCOxUmxPjM" Ids="Nvy8eap9kT2LiKZV7MIt8a,E1TsUTgVENaPfI6jz7Jh7V" />
-        <Link Id="OVH7BSzBUiXNKPPCo5AA4W" Ids="NDklh8g9HkZMV6OgSS8gFe,TjvbvzE1kqTQaGzWY1G2Sn" />
-        <Link Id="SRXTpVcxhaiNxrUhBXMLvu" Ids="K48Ts8Xv7zGODPf8lnNdHq,SuPpUKShbvnLn1jI5p0dqu" />
         <Link Id="G9gLCmxjZbhLRjx7DwUo3N" Ids="TCEBzKvTg7tPdrYT8fR3eO,Qcqpxmbb3OoMnDVOTHIScd" />
+        <Link Id="Oh0MHTvA0M6OPGL9MvC8OC" Ids="NDklh8g9HkZMV6OgSS8gFe,TjvbvzE1kqTQaGzWY1G2Sn" />
+        <Link Id="F6EdWcqsmpHOLrQahlaHOq" Ids="Nvy8eap9kT2LiKZV7MIt8a,E1TsUTgVENaPfI6jz7Jh7V" />
+        <Link Id="OI5V1MnFe2tPdaoucifYqv" Ids="K48Ts8Xv7zGODPf8lnNdHq,SuPpUKShbvnLn1jI5p0dqu" />
       </Patch>
     </Node>
   </Patch>

--- a/packages/VL.Stride.Runtime/help/PostFX/HowTo Add Film Grain.vl
+++ b/packages/VL.Stride.Runtime/help/PostFX/HowTo Add Film Grain.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="OegN4jXXQNKNqfFFrq6qER" LanguageVersion="2021.3.0.21" Version="0.128">
-  <NugetDependency Id="Rq1hxtGm4prLgcbPnzpr1q" Location="VL.CoreLib" Version="2021.3.0-0021-g44253d2755" />
+<Document xmlns:p="property" Id="OegN4jXXQNKNqfFFrq6qER" LanguageVersion="2021.3.0.42" Version="0.128">
+  <NugetDependency Id="Rq1hxtGm4prLgcbPnzpr1q" Location="VL.CoreLib" Version="2020.3.0-0092-gae02f44ee4" />
   <Patch Id="EflKC5Ddi2BN1mZWLv60qK">
     <Canvas Id="NBB3K3ClmntMsyQxzUGU5L" DefaultCategory="Main" BordersChecked="false" CanvasType="FullCategory" />
     <!--
@@ -29,7 +29,7 @@
             <Pin Id="FBg84hgpoZHMjRad5Gwy6O" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="477,747,225,19" Id="VWjP0xYyHomPnfyK2E0sfp">
-            <p:NodeReference LastCategoryFullName="Stride" LastSymbolSource="VL.Stride.Windowing.vl">
+            <p:NodeReference LastCategoryFullName="Stride" LastSymbolSource="VL.Stride.Engine.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SceneWindow" />
             </p:NodeReference>
@@ -75,11 +75,13 @@
               <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
             </p:ValueBoxSettings>
           </Pad>
-          <Node Bounds="638,661,165,19" Id="VtTSY54dU3nOkpuRqfXkZt">
-            <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Rendering.Nodes">
+          <Node Bounds="778,661,185,19" Id="VtTSY54dU3nOkpuRqfXkZt">
+            <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Engine.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessNode" Name="PostFX" />
             </p:NodeReference>
+            <Pin Id="BcjCuhrEYtNLfCf6QjecPY" Name="Color Transforms" Kind="InputPin" />
+            <Pin Id="Dcq0jbJUzI9LX88K0S2YYN" Name="Enable Default ToneMap" Kind="InputPin" />
             <Pin Id="UyojHOFKDXlMC1ulURyVgc" Name="Ambient Occlusion" Kind="InputPin" />
             <Pin Id="KhiYK9CgtrsN42DWJ5gHyo" Name="Local Reflections" Kind="InputPin" />
             <Pin Id="KJ7jHiQoskbQMHiuXK3qUJ" Name="Depth Of Field" Kind="InputPin" />
@@ -87,7 +89,6 @@
             <Pin Id="NBEC1CTLvLNP8XqyT7a8HG" Name="Bloom" Kind="InputPin" />
             <Pin Id="IGlfzuvia71QHei6BjR4bQ" Name="Light Streak" Kind="InputPin" />
             <Pin Id="NrqLVAoxklKOyJy2MSh6RJ" Name="Lens Flare" Kind="InputPin" />
-            <Pin Id="BcjCuhrEYtNLfCf6QjecPY" Name="Color Transforms" Kind="InputPin" />
             <Pin Id="IDaA3jKL385NBtXdTbuXH8" Name="Antialiasing" Kind="InputPin" />
             <Pin Id="TkLfleaG9glNLYCMrplHya" Name="Output" Kind="OutputPin" />
           </Node>
@@ -335,5 +336,5 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="O4cakjMGDhTLmzD7Q9aWkK" Location="VL.Stride" Version="0.9.38-gbc5ac785f1" />
+  <NugetDependency Id="O4cakjMGDhTLmzD7Q9aWkK" Location="VL.Stride" Version="0.9.53-gf91822d3de" />
 </Document>

--- a/packages/VL.Stride.Runtime/help/PostFX/HowTo Add Vignette.vl
+++ b/packages/VL.Stride.Runtime/help/PostFX/HowTo Add Vignette.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="NGn7PXhR5zeN3snIbPW861" LanguageVersion="2021.3.0.21" Version="0.128">
-  <NugetDependency Id="Rq1hxtGm4prLgcbPnzpr1q" Location="VL.CoreLib" Version="2021.3.0-0021-g44253d2755" />
+<Document xmlns:p="property" Id="NGn7PXhR5zeN3snIbPW861" LanguageVersion="2021.3.0.42" Version="0.128">
+  <NugetDependency Id="Rq1hxtGm4prLgcbPnzpr1q" Location="VL.CoreLib" Version="2020.3.0-0092-gae02f44ee4" />
   <Patch Id="EflKC5Ddi2BN1mZWLv60qK">
     <Canvas Id="NBB3K3ClmntMsyQxzUGU5L" DefaultCategory="Main" BordersChecked="false" CanvasType="FullCategory" />
     <!--
@@ -29,7 +29,7 @@
             <Pin Id="FBg84hgpoZHMjRad5Gwy6O" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="478,734,225,19" Id="VWjP0xYyHomPnfyK2E0sfp">
-            <p:NodeReference LastCategoryFullName="Stride" LastSymbolSource="VL.Stride.Windowing.vl">
+            <p:NodeReference LastCategoryFullName="Stride" LastSymbolSource="VL.Stride.Engine.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SceneWindow" />
             </p:NodeReference>
@@ -75,11 +75,13 @@
               <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
             </p:ValueBoxSettings>
           </Pad>
-          <Node Bounds="638,661,165,19" Id="VtTSY54dU3nOkpuRqfXkZt">
-            <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Rendering.Nodes">
+          <Node Bounds="732,654,185,19" Id="VtTSY54dU3nOkpuRqfXkZt">
+            <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Engine.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessNode" Name="PostFX" />
             </p:NodeReference>
+            <Pin Id="BcjCuhrEYtNLfCf6QjecPY" Name="Color Transforms" Kind="InputPin" />
+            <Pin Id="VoHYeqSJB2dLnQmN8r00pZ" Name="Enable Default ToneMap" Kind="InputPin" />
             <Pin Id="UyojHOFKDXlMC1ulURyVgc" Name="Ambient Occlusion" Kind="InputPin" />
             <Pin Id="KhiYK9CgtrsN42DWJ5gHyo" Name="Local Reflections" Kind="InputPin" />
             <Pin Id="KJ7jHiQoskbQMHiuXK3qUJ" Name="Depth Of Field" Kind="InputPin" />
@@ -87,7 +89,6 @@
             <Pin Id="NBEC1CTLvLNP8XqyT7a8HG" Name="Bloom" Kind="InputPin" />
             <Pin Id="IGlfzuvia71QHei6BjR4bQ" Name="Light Streak" Kind="InputPin" />
             <Pin Id="NrqLVAoxklKOyJy2MSh6RJ" Name="Lens Flare" Kind="InputPin" />
-            <Pin Id="BcjCuhrEYtNLfCf6QjecPY" Name="Color Transforms" Kind="InputPin" />
             <Pin Id="IDaA3jKL385NBtXdTbuXH8" Name="Antialiasing" Kind="InputPin" />
             <Pin Id="TkLfleaG9glNLYCMrplHya" Name="Output" Kind="OutputPin" />
           </Node>
@@ -146,7 +147,7 @@
             <Pin Id="ImpW8N6vkhtQHGjjzrxTTp" Name="Enabled" Kind="InputPin" />
             <Pin Id="QM2YAbuHUwTNJDXFR2hAYk" Name="Entity" Kind="OutputPin" />
           </Node>
-          <Overlay Id="QLufNrq8z3RPLK663HOU9H" Name="Film Grain" Bounds="613,468,404,238" />
+          <Overlay Id="QLufNrq8z3RPLK663HOU9H" Name="Vignette" Bounds="613,468,404,238" />
           <Pad Id="SK6MXPMbtsiOGclbl2Csqe" Bounds="91,307,261,22" ShowValueBox="true" isIOBox="true" Value="For more information, see:">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="String" />
@@ -165,7 +166,7 @@
               <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Link</p:stringtype>
             </p:ValueBoxSettings>
           </Pad>
-          <Node Bounds="778,624,65,19" Id="PSiSQcQDeSSPSlV6aekTGg">
+          <Node Bounds="732,617,65,19" Id="PSiSQcQDeSSPSlV6aekTGg">
             <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="FromValue" />
@@ -259,7 +260,7 @@
               <Choice Kind="TypeFlag" Name="RGBA" />
             </p:TypeAnnotation>
           </Pad>
-          <Node Bounds="778,593,65,19" Id="D4ejdrJ4kSuOIkl1iE7NRN">
+          <Node Bounds="732,580,65,19" Id="D4ejdrJ4kSuOIkl1iE7NRN">
             <p:NodeReference LastCategoryFullName="Stride.Rendering.PostFX.ColorTransforms" LastSymbolSource="VL.Stride.Rendering.Nodes">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessNode" Name="Vignetting" />
@@ -271,17 +272,17 @@
             <Pin Id="M4cD9ZEjNNeOqvkOOd1lSo" Name="Enabled" Kind="InputPin" />
             <Pin Id="MoOxqvosfjRM9OdrgoavtZ" Name="Output" Kind="OutputPin" />
           </Node>
-          <Pad Id="K5Pz7jYSgD5OJuETGM5OSe" Comment="Amount" Bounds="700,533,35,15" ShowValueBox="true" isIOBox="true" Value="0.8">
+          <Pad Id="K5Pz7jYSgD5OJuETGM5OSe" Comment="Amount" Bounds="654,520,35,15" ShowValueBox="true" isIOBox="true" Value="0.8">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="LB8OSHAmH0pOgkcHNG18vG" Comment="Radius" Bounds="800,531,35,15" ShowValueBox="true" isIOBox="true" Value="0.61">
+          <Pad Id="LB8OSHAmH0pOgkcHNG18vG" Comment="Radius" Bounds="754,518,35,15" ShowValueBox="true" isIOBox="true" Value="0.61">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="HXPV4Mjom0sOEgEXanAyYp" Comment="Color" Bounds="820,563,45,20" ShowValueBox="true" isIOBox="true" Value="0, 0, 0, 1">
+          <Pad Id="HXPV4Mjom0sOEgEXanAyYp" Comment="Color" Bounds="774,550,45,20" ShowValueBox="true" isIOBox="true" Value="0, 0, 0, 1">
             <p:TypeAnnotation LastCategoryFullName="Color" LastSymbolSource="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="RGBA" />
             </p:TypeAnnotation>
@@ -316,5 +317,5 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="O4cakjMGDhTLmzD7Q9aWkK" Location="VL.Stride" Version="0.9.38-gbc5ac785f1" />
+  <NugetDependency Id="O4cakjMGDhTLmzD7Q9aWkK" Location="VL.Stride" Version="0.9.53-gf91822d3de" />
 </Document>

--- a/packages/VL.Stride.Runtime/help/PostFX/HowTo Debug PostFX.vl
+++ b/packages/VL.Stride.Runtime/help/PostFX/HowTo Debug PostFX.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="LF7ZuxSzzVFMbbMM4UXRU9" LanguageVersion="2021.3.0.21" Version="0.128">
-  <NugetDependency Id="Rq1hxtGm4prLgcbPnzpr1q" Location="VL.CoreLib" Version="2021.3.0-0021-g44253d2755" />
+<Document xmlns:p="property" Id="LF7ZuxSzzVFMbbMM4UXRU9" LanguageVersion="2021.3.0.42" Version="0.128">
+  <NugetDependency Id="Rq1hxtGm4prLgcbPnzpr1q" Location="VL.CoreLib" Version="2020.3.0-0092-gae02f44ee4" />
   <Patch Id="EflKC5Ddi2BN1mZWLv60qK">
     <Canvas Id="NBB3K3ClmntMsyQxzUGU5L" DefaultCategory="Main" CanvasType="FullCategory">
       <!--
@@ -1090,10 +1090,12 @@
             <Pin Id="C4rSd0sYo1QP4lHmwX2WpM" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="435,516,642,19" Id="HorTyWonQGMNuW9Yhzh8mo">
-            <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Rendering.Nodes">
+            <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Engine.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessNode" Name="PostFX" />
             </p:NodeReference>
+            <Pin Id="FLuUiqRGOD6PNdIPic8w7l" Name="Color Transforms" Kind="InputPin" />
+            <Pin Id="J6yRd3QSQPZNgNIoZRgih5" Name="Enable Default ToneMap" Kind="InputPin" />
             <Pin Id="SRYWBeTCFz1MJD07wCCvAh" Name="Ambient Occlusion" Kind="InputPin" />
             <Pin Id="AmN4pHeXRB6Pb4McNIAMn0" Name="Local Reflections" Kind="InputPin" />
             <Pin Id="Ee1me8K69a4NEgDag7rpj5" Name="Depth Of Field" Kind="InputPin" />
@@ -1101,7 +1103,6 @@
             <Pin Id="KhOgof6T5ZtOWuCRskzR0Y" Name="Bloom" Kind="InputPin" />
             <Pin Id="R0tWPftbicnNJmVOFMrfs8" Name="Light Streak" Kind="InputPin" />
             <Pin Id="AUozuHpszdkPbbqbhq2Nzl" Name="Lens Flare" Kind="InputPin" />
-            <Pin Id="FLuUiqRGOD6PNdIPic8w7l" Name="Color Transforms" Kind="InputPin" />
             <Pin Id="DxxKeQYNg2aMjB9puP4msc" Name="Antialiasing" Kind="InputPin" />
             <Pin Id="L8nx2YaOqKKNkLhYQur076" Name="Output" Kind="OutputPin" />
           </Node>
@@ -1116,7 +1117,7 @@
             <Pin Id="F5dseKxam6lQKf13m5uMnM" Name="Output" Kind="OutputPin" />
             <Pin Id="HuuhHDnIT5kPHln5shVGKb" Name="Result" Kind="OutputPin" />
           </Node>
-          <Node Bounds="1017,457,65,19" Id="UUhUrPXoDJFMGh9261P5ei">
+          <Node Bounds="419,351,65,19" Id="UUhUrPXoDJFMGh9261P5ei">
             <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="FromValue" />
@@ -1126,7 +1127,7 @@
             <Pin Id="IQiQS5pG90DOC8ySALVjJj" Name="Result" Kind="OutputPin" />
             <Pin Id="ENJVdS2GppNNguVz1QkSsQ" Name="Input 2" Kind="InputPin" />
           </Node>
-          <Node Bounds="1016,395,225,19" Id="Ufz7aYKZ8i9LlNLdMtEqTx">
+          <Node Bounds="418,289,225,19" Id="Ufz7aYKZ8i9LlNLdMtEqTx">
             <p:NodeReference LastCategoryFullName="Stride.Rendering.PostFX.ColorTransforms" LastSymbolSource="VL.Stride.Rendering.Nodes">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessNode" Name="ToneMap" />
@@ -1169,7 +1170,7 @@
             <Pin Id="VLq2xk3q3CIP0xZGaNUk3s" Name="Enabled" Kind="InputPin" />
             <Pin Id="APlgeMorbsTLUioA9Fzd0O" Name="Output" Kind="OutputPin" />
           </Node>
-          <Node Bounds="383,417,185,19" Id="CbvNGImgsJJMwLVGKAyeLG">
+          <Node Bounds="534,395,185,19" Id="CbvNGImgsJJMwLVGKAyeLG">
             <p:NodeReference LastCategoryFullName="Stride.Rendering.PostFX" LastSymbolSource="VL.Stride.Rendering.Nodes">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessNode" Name="AmbientOcclusion" />
@@ -1206,7 +1207,7 @@
             </Pin>
             <Pin Id="NFDfVnf036pPLUKJd5siOs" Name="Output" Kind="OutputPin" />
           </Node>
-          <Node Bounds="725,334,66,19" Id="PpOYzXFbqmQLfxtsayFOdt">
+          <Node Bounds="830,296,66,19" Id="PpOYzXFbqmQLfxtsayFOdt">
             <p:NodeReference LastCategoryFullName="Stride.Rendering.PostFX" LastSymbolSource="VL.Stride.Runtime.dll">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="BrightFilter" />
@@ -1230,7 +1231,7 @@
             </Pin>
             <Pin Id="CbOM16VBhewQdJRaNBPdNA" Name="Output" Kind="OutputPin" />
           </Node>
-          <Node Bounds="755,372,125,19" Id="P6HCMeYMSr3L4yeOhQv13m">
+          <Node Bounds="872,352,125,19" Id="P6HCMeYMSr3L4yeOhQv13m">
             <p:NodeReference LastCategoryFullName="Stride.Rendering.PostFX" LastSymbolSource="VL.Stride.Rendering.Nodes">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessNode" Name="Bloom" />
@@ -1260,7 +1261,7 @@
             <Pin Id="LtDSESV2XSpNPP3nXyXowm" Name="Enabled" Kind="InputPin" />
             <Pin Id="KnOPHhklNQAPHZTLGhSclq" Name="Output" Kind="OutputPin" />
           </Node>
-          <Node Bounds="587,415,105,19" Id="GjBYdxyT4TfLsCWeKhlLet">
+          <Node Bounds="684,343,105,19" Id="GjBYdxyT4TfLsCWeKhlLet">
             <p:NodeReference LastCategoryFullName="Stride.Rendering.PostFX" LastSymbolSource="VL.Stride.Rendering.Nodes">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessNode" Name="DepthOfField" />
@@ -1285,7 +1286,7 @@
             </Pin>
             <Pin Id="BC3sddEhhguLrFiKZxNeUb" Name="Output" Kind="OutputPin" />
           </Node>
-          <Node Bounds="833,411,125,19" Id="LXIiDJSK7URQZ7Jk0lPuoT">
+          <Node Bounds="1000,394,125,19" Id="LXIiDJSK7URQZ7Jk0lPuoT">
             <p:NodeReference LastCategoryFullName="Stride.Rendering.PostFX" LastSymbolSource="VL.Stride.Rendering.Nodes">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessNode" Name="LightStreak" />
@@ -1323,7 +1324,7 @@
             </Pin>
             <Pin Id="JEjUzRyLv2PPDlYaW3C2iw" Name="Output" Kind="OutputPin" />
           </Node>
-          <Node Bounds="1077,428,65,19" Id="Rq4rNvYGLckMCKSXX9mPBX">
+          <Node Bounds="479,322,65,19" Id="Rq4rNvYGLckMCKSXX9mPBX">
             <p:NodeReference LastCategoryFullName="Stride.Rendering.PostFX.ColorTransforms" LastSymbolSource="VL.Stride.Rendering.Nodes">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessNode" Name="Vignetting" />
@@ -1346,7 +1347,7 @@
             <Pin Id="LojfBaDjHXGMAxmUSQWZQ6" Name="Enabled" Kind="InputPin" />
             <Pin Id="Ah6KbBSJJXUOJOl7EmaQfQ" Name="Output" Kind="OutputPin" />
           </Node>
-          <Pad Id="D9lvhrQsujWOTjyOklxivt" Comment="DOFAreas" Bounds="606,306,41,57" ShowValueBox="true" isIOBox="true" Value="0.5, 1.89, 4.32, 50">
+          <Pad Id="D9lvhrQsujWOTjyOklxivt" Comment="DOFAreas" Bounds="703,234,41,57" ShowValueBox="true" isIOBox="true" Value="0.5, 1.89, 4.32, 50">
             <p:TypeAnnotation LastCategoryFullName="3D" LastSymbolSource="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="Vector4" />
             </p:TypeAnnotation>
@@ -1373,7 +1374,7 @@
             </p:TypeAnnotation>
           </Pad>
           <Node Bounds="78,786,290,19" Id="TyIuMDh43vXNpikMLP3jZh">
-            <p:NodeReference LastCategoryFullName="Stride" LastSymbolSource="VL.Stride.Windowing.vl">
+            <p:NodeReference LastCategoryFullName="Stride" LastSymbolSource="VL.Stride.Engine.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SceneWindow" />
             </p:NodeReference>
@@ -1410,7 +1411,7 @@
             </p:NodeReference>
             <Pin Id="L4JgCRqFq86P38PyrJ5ED6" Name="Output" Kind="OutputPin" />
           </Node>
-          <Node Bounds="476,463,285,19" Id="RTBCXF8Y6d2MgsMMWJ50AC">
+          <Node Bounds="619,441,285,19" Id="RTBCXF8Y6d2MgsMMWJ50AC">
             <p:NodeReference LastCategoryFullName="Stride.Rendering.PostFX" LastSymbolSource="VL.Stride.Rendering.Nodes">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessNode" Name="LocalReflections" />
@@ -1448,7 +1449,7 @@
             <Pin Id="OgYu8F0UMAdP2GLRTaLTnG" Name="Enabled" Kind="InputPin" />
             <Pin Id="Cz8GckbdDMKPIPORsPC5yY" Name="Output" Kind="OutputPin" />
           </Node>
-          <Node Bounds="899,468,65,19" Id="VsHWQXbQxE4LD3TWHbPGya">
+          <Node Bounds="1066,451,65,19" Id="VsHWQXbQxE4LD3TWHbPGya">
             <p:NodeReference LastCategoryFullName="Stride.Rendering.PostFX" LastSymbolSource="VL.Stride.Rendering.Nodes">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessNode" Name="LensFlare" />
@@ -1512,5 +1513,5 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="O4cakjMGDhTLmzD7Q9aWkK" Location="VL.Stride" Version="0.9.38-gbc5ac785f1" />
+  <NugetDependency Id="O4cakjMGDhTLmzD7Q9aWkK" Location="VL.Stride" Version="0.9.53-gf91822d3de" />
 </Document>

--- a/packages/VL.Stride.Runtime/help/Rendering/HowTo Render a Scene twice.vl
+++ b/packages/VL.Stride.Runtime/help/Rendering/HowTo Render a Scene twice.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="PeQdR906USMP2yVtpLknYo" LanguageVersion="2020.3.0.19" Version="0.128">
-  <NugetDependency Id="Rq1hxtGm4prLgcbPnzpr1q" Location="VL.CoreLib" Version="2020.2.0-0299-g69e2ac598b" />
+<Document xmlns:p="property" Id="PeQdR906USMP2yVtpLknYo" LanguageVersion="2021.3.0.42" Version="0.128">
+  <NugetDependency Id="Rq1hxtGm4prLgcbPnzpr1q" Location="VL.CoreLib" Version="2020.3.0-0092-gae02f44ee4" />
   <Patch Id="EflKC5Ddi2BN1mZWLv60qK">
     <Canvas Id="NBB3K3ClmntMsyQxzUGU5L" DefaultCategory="Main" BordersChecked="false" CanvasType="FullCategory" />
     <!--
@@ -28,13 +28,10 @@
             <Pin Id="Jf04j3ht9seNd6YV9p1PcF" Name="Size" Kind="InputPin" />
             <Pin Id="VXZiUpuP9MfMwh46LRcCqI" Name="Tessellation" Kind="InputPin" />
             <Pin Id="KQHnbMmJQVcQL4xqiI13OJ" Name="Normal" Kind="InputPin" />
-            <Pin Id="APUx6LV1dKcM3TC6urQGIk" Name="Generate Back Face" Kind="InputPin">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="TypeFlag" Name="Boolean" />
-              </p:TypeAnnotation>
-            </Pin>
+            <Pin Id="APUx6LV1dKcM3TC6urQGIk" Name="Generate Back Face" Kind="InputPin" />
             <Pin Id="OH1cvhBSa0kLEuNa7cgJMy" Name="Material" Kind="InputPin" />
             <Pin Id="H5f3tJvIb8COdAJlsBL4Sc" Name="Is Shadow Caster" Kind="InputPin" />
+            <Pin Id="AlZX93a8j6XNqaRo7LDWqn" Name="Components" Kind="InputPin" />
             <Pin Id="Kd9lKkeMm8rMGKD0DRFROh" Name="Children" Kind="InputPin" />
             <Pin Id="CcJ3WL6RwgTM3iYeiH8qKO" Name="Name" Kind="InputPin" />
             <Pin Id="KsV0noRN1QkPxFWWM4BpLF" Name="Enabled" Kind="InputPin" />
@@ -53,6 +50,8 @@
             <Pin Id="L6WGkWiUQuoMVkw9jnYVp2" Name="Target" Kind="InputPin" />
             <Pin Id="Fj28hWfYRqhNid0G6fgoKi" Name="Color" Kind="InputPin" />
             <Pin Id="QGDNpO3JnrdO8Tx9V9Muj1" Name="Intensity" Kind="InputPin" />
+            <Pin Id="CgvSJOyOg4EMp2UcO6Zlkw" Name="Shadow" Kind="InputPin" />
+            <Pin Id="I9z9TKeVhzxO4yzaAXzcI9" Name="Enable Default Shadow" Kind="InputPin" />
             <Pin Id="JPv9tYgcrsPO3oKRlfshX3" Name="Component" Kind="InputPin" />
             <Pin Id="JsVGqXTrRS2P9iI71MZDGr" Name="Children" Kind="InputPin" />
             <Pin Id="IZuMF58Luc4MWqrIiHIPxX" Name="Name" Kind="InputPin" />
@@ -73,6 +72,7 @@
             <Pin Id="MfeuL0gDZsVNlBQT5ldEuY" Name="Tessellation" Kind="InputPin" />
             <Pin Id="Pt62cx70GiFQMAL9T3cuzm" Name="Material" Kind="InputPin" />
             <Pin Id="KlR9tHZScg7LVGyDq25uoK" Name="Is Shadow Caster" Kind="InputPin" />
+            <Pin Id="R1U8omi70UeNsSuVt3gP8M" Name="Components" Kind="InputPin" />
             <Pin Id="AXpa9FGQrEeLCzBATXGdc8" Name="Children" Kind="InputPin" />
             <Pin Id="UyF0L2YLDphLm9pDr7jNTt" Name="Name" Kind="InputPin" />
             <Pin Id="AIv4nDnjMeiPnBEvRFT3t7" Name="Enabled" Kind="InputPin" />
@@ -91,13 +91,14 @@
             <Pin Id="J6aOPfe9xfvOR7lqSieuSD" Name="Size" Kind="InputPin" />
             <Pin Id="NG85zc4wmk9OpjKIrYvKrg" Name="Material" Kind="InputPin" />
             <Pin Id="BT1h7JopKPeM5JVgiCJySo" Name="Is Shadow Caster" Kind="InputPin" />
+            <Pin Id="Nb97ro2PxWCMBhJWUtKaXV" Name="Components" Kind="InputPin" />
             <Pin Id="AitQ1bdHKfpMLBcGW2AtPe" Name="Children" Kind="InputPin" />
             <Pin Id="VV1C6aDzvwROoxGH3Fr06J" Name="Name" Kind="InputPin" />
             <Pin Id="CFWUxGaVQjTPyV4TvFjpKS" Name="Enabled" Kind="InputPin" />
             <Pin Id="VmNXK5xb8d1NpMdgHrZ2tz" Name="Entity" Kind="OutputPin" />
           </Node>
           <Node Bounds="210,670,225,19" Id="QAmiTpurIQgNVrEehueSZu">
-            <p:NodeReference LastCategoryFullName="Stride" LastSymbolSource="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride" LastSymbolSource="VL.Stride.Engine.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SceneWindow" />
             </p:NodeReference>
@@ -113,20 +114,12 @@
             </Pin>
             <Pin Id="KFhV8Lg3eJyMCjnQk1wppP" Name="Input" Kind="InputPin" />
             <Pin Id="Rg5eMxSA0WrLxFXA0pgaDL" Name="Camera" Kind="InputPin" />
-            <Pin Id="DIaIMH9Vb4DORoQcVwPWzP" Name="Enable Default Camera" Kind="InputPin">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="TypeFlag" Name="Boolean" />
-              </p:TypeAnnotation>
-            </Pin>
+            <Pin Id="DIaIMH9Vb4DORoQcVwPWzP" Name="Enable Default Camera" Kind="InputPin" />
             <Pin Id="JjfFoBLLO29QdAB5fDmJGa" Name="Title" Kind="InputPin" />
             <Pin Id="FfVCWUWVNeZLO80BMEExJu" Name="Clear Color" Kind="InputPin" />
             <Pin Id="G2ZIXqeQoXvM7mdWt4sFmi" Name="Clear" Kind="InputPin" />
             <Pin Id="Q3taz30IlDVObClMvQBMnl" Name="Post Effects" Kind="InputPin" />
-            <Pin Id="DcmvhPOBSeAOdEFOOEPl5Q" Name="Enable Default Post Effects" Kind="InputPin">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="TypeFlag" Name="Boolean" />
-              </p:TypeAnnotation>
-            </Pin>
+            <Pin Id="DcmvhPOBSeAOdEFOOEPl5Q" Name="Enable Default Post Effects" Kind="InputPin" />
             <Pin Id="EDQPe3GWQZrM4H56FvqKQ7" Name="Enable Keyboard Shortcuts" Kind="InputPin" />
             <Pin Id="OnvrUG7sR5gMQNTdVdiVhA" Name="Enabled" Kind="InputPin" />
             <Pin Id="KW6QgiqkeGYLxuTB87ORvy" Name="Output" Kind="OutputPin" />
@@ -136,7 +129,7 @@
             <Pin Id="QrEEov4xDlwOR8iwbQnhDc" Name="Depth Buffer" Kind="OutputPin" />
           </Node>
           <Node Bounds="453,582,205,19" Id="BIpht7y0vbhPAKRzEb0fxi">
-            <p:NodeReference LastCategoryFullName="Stride" LastSymbolSource="VL.Stride.vl">
+            <p:NodeReference LastCategoryFullName="Stride" LastSymbolSource="VL.Stride.Engine.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SceneWindow" />
             </p:NodeReference>
@@ -165,11 +158,7 @@
             </Pin>
             <Pin Id="NPi3z4EEADmO7oRBXpRQNW" Name="Clear" Kind="InputPin" />
             <Pin Id="NPdvq5USOKUPrWeMt9V27u" Name="Post Effects" Kind="InputPin" />
-            <Pin Id="FUQVeIVw638MF35utauC8H" Name="Enable Default Post Effects" Kind="InputPin">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="TypeFlag" Name="Boolean" />
-              </p:TypeAnnotation>
-            </Pin>
+            <Pin Id="FUQVeIVw638MF35utauC8H" Name="Enable Default Post Effects" Kind="InputPin" />
             <Pin Id="NUA8e2pP9SYLHzdHbRx2ok" Name="Enable Keyboard Shortcuts" Kind="InputPin" />
             <Pin Id="IZrwJIuWPbUN8Y38s4Yb1l" Name="Enabled" Kind="InputPin" />
             <Pin Id="QlvIuQJBvSiP0TvTLr7xxV" Name="Output" Kind="OutputPin" />
@@ -191,29 +180,21 @@
             <Pin Id="SinGFkKZzcfQVHaY0A60vd" Name="Enabled" Kind="InputPin" />
             <Pin Id="GJKcFF13ljDQMGEcbariKa" Name="Output" Kind="OutputPin" />
           </Node>
-          <Node Bounds="651,499,105,19" Id="F9vn5orBVKjLuhn7G1ovGs">
+          <Node Bounds="693,503,105,19" Id="F9vn5orBVKjLuhn7G1ovGs">
             <p:NodeReference LastCategoryFullName="Stride.Rendering.PostFX" LastSymbolSource="VL.Stride.Runtime.dll">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <CategoryReference Kind="Category" Name="PostFX" />
               <Choice Kind="ProcessNode" Name="DepthOfField" />
             </p:NodeReference>
             <Pin Id="MC25LBdFRuXLZtexhpoJM0" Name="Size" Kind="InputPin" />
-            <Pin Id="QfdYTwmqGmpLnR0tMU6gyI" Name="DOFAreas" Kind="InputPin">
-              <p:TypeAnnotation LastCategoryFullName="3D" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="TypeFlag" Name="Vector4" />
-              </p:TypeAnnotation>
-            </Pin>
+            <Pin Id="QfdYTwmqGmpLnR0tMU6gyI" Name="DOFAreas" Kind="InputPin" />
             <Pin Id="CufS9olHo7BMGnQSaPagtd" Name="Quality Preset" Kind="InputPin" DefaultValue="0.5">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="Ls3uYyvpMC5O8Qkr4acAE6" Name="Technique" Kind="InputPin" />
-            <Pin Id="AqxsCdHeM0nPLufO5QKoSa" Name="Auto Focus" Kind="InputPin">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="TypeFlag" Name="Boolean" />
-              </p:TypeAnnotation>
-            </Pin>
+            <Pin Id="AqxsCdHeM0nPLufO5QKoSa" Name="Auto Focus" Kind="InputPin" />
             <Pin Id="VF1tekGBDF0MG2uMvFdmxr" Name="Enabled" Kind="InputPin" DefaultValue="True">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Boolean" />
@@ -222,10 +203,12 @@
             <Pin Id="THZC0xYM1vRNfC0FlyAZQ4" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="613,536,165,19" Id="FNRVA8DSJShOOUG8KHO5HW">
-            <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Rendering.Nodes">
+            <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Engine.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessNode" Name="PostFX" />
             </p:NodeReference>
+            <Pin Id="VkrRFIREBrjNdfJlpOD52z" Name="Color Transforms" Kind="InputPin" />
+            <Pin Id="LGouDyzKXvkMNQK8DVV8TQ" Name="Enable Default ToneMap" Kind="InputPin" />
             <Pin Id="D4Go1Ug5lbxLzjQwoFC0vg" Name="Ambient Occlusion" Kind="InputPin" />
             <Pin Id="CY3loi0mLTrPyk4iDMctEU" Name="Local Reflections" Kind="InputPin" />
             <Pin Id="U3QBEr0EN9ULRV5J7GV3JB" Name="Depth Of Field" Kind="InputPin" />
@@ -233,7 +216,6 @@
             <Pin Id="NVUCqI2Ks5zORC11oYnOVF" Name="Bloom" Kind="InputPin" />
             <Pin Id="DyKrcWpT4wNP3uYF6tCnvF" Name="Light Streak" Kind="InputPin" />
             <Pin Id="FxVYsYgbEdGO07E3HC9Swj" Name="Lens Flare" Kind="InputPin" />
-            <Pin Id="VkrRFIREBrjNdfJlpOD52z" Name="Color Transforms" Kind="InputPin" />
             <Pin Id="GsLz9tW5i11PnwkeTdAYRX" Name="Antialiasing" Kind="InputPin" />
             <Pin Id="TUaILCm1jnXMTexh0qsFgK" Name="Output" Kind="OutputPin" />
           </Node>
@@ -283,13 +265,6 @@
             <Pin Id="LAAdpCst4XENJJX3ZnkHTe" Name="Inverse View" Kind="OutputPin" />
             <Pin Id="Sk1zGq9sumtNnn1ltDjfev" Name="Camera Component" Kind="OutputPin" />
           </Node>
-          <Node Bounds="766,498,91,19" Id="O8yPR5qEKUlPy5bAUPvBBi">
-            <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Engine.vl">
-              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-              <Choice Kind="ProcessAppFlag" Name="DefaultToneMap" />
-            </p:NodeReference>
-            <Pin Id="JIRCZnzR8NwQF7ViuQuuLS" Name="Result" Kind="OutputPin" />
-          </Node>
           <Pad Id="AgGeXQPX3vVMWxQgaeuk2u" Bounds="439,668,206,46" ShowValueBox="true" isIOBox="true" Value="press F4 on the lower window to get an overview over the setup. ">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="String" />
@@ -314,12 +289,11 @@
         <Link Id="PL5SiTpUnXHLJn9JHoYWWf" Ids="RXJyKlXbWORQYTCG1OPxMX,PNoJzcBAWyFPm3lpcrxNqX" />
         <Link Id="QZovVVXI2p2PUAKUomDmVC" Ids="TUaILCm1jnXMTexh0qsFgK,NPdvq5USOKUPrWeMt9V27u" />
         <Link Id="CpVeCaX8WEtMvhDQ9UOch7" Ids="THZC0xYM1vRNfC0FlyAZQ4,U3QBEr0EN9ULRV5J7GV3JB" />
-        <Link Id="Re3y6ZUJQfzP3UXX782Fnt" Ids="JIRCZnzR8NwQF7ViuQuuLS,VkrRFIREBrjNdfJlpOD52z" />
         <Link Id="L1NqdCTL4CQLubeVQF4oPz" Ids="Oajw34PfyTyOlgISyvm4yc,Dme2vpxolqVPYFkYPsfdAc" />
         <Link Id="A5X6a0k31pAQZbeycgALDm" Ids="Oajw34PfyTyOlgISyvm4yc,SnlQVK6tKH6PlKdGD1a0Yi" />
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="O4cakjMGDhTLmzD7Q9aWkK" Location="VL.Stride" Version="0.7.481-ga1d976a698" />
-  <NugetDependency Id="Mcnpcocp0SfPUs1XkgPpcD" Location="VL.Skia" Version="2020.2.0-0299-g69e2ac598b" />
+  <NugetDependency Id="O4cakjMGDhTLmzD7Q9aWkK" Location="VL.Stride" Version="0.9.53-gf91822d3de" />
+  <NugetDependency Id="Mcnpcocp0SfPUs1XkgPpcD" Location="VL.Skia" Version="2020.3.0-0092-gae02f44ee4" />
 </Document>

--- a/packages/VL.Stride.Runtime/src/Rendering/Compositing/CompositingNodes.cs
+++ b/packages/VL.Stride.Runtime/src/Rendering/Compositing/CompositingNodes.cs
@@ -275,7 +275,7 @@ namespace VL.Stride.Rendering.Compositing
 
             IVLNodeDescription CreatePostEffectsNode()
             {
-                return nodeFactory.NewNode<PostProcessingEffects>(name: "PostFX", category: renderingCategory, copyOnWrite: false, 
+                return nodeFactory.NewNode<PostProcessingEffects>(name: "PostFXCore (Internal)", category: renderingCategory, copyOnWrite: false, 
                     init: effects =>
                     {
                         // Can't use effects.DisableAll() - disables private effects used by AA


### PR DESCRIPTION
This simplifies the PostFX node usage. You don't need to know anymore that when using your own PostFX, that you should use a DefaultToneMap and connect the Result to the PostFx, just to get the behavior that had before using your own PostFX.