### PR TITLE
ColorMap and ValueMap can have multiple sinks

### DIFF
--- a/packages/VL.Stride.Runtime/VL.Stride.Rendering.ShaderFX.vl
+++ b/packages/VL.Stride.Runtime/VL.Stride.Rendering.ShaderFX.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="IeOwK5mcmYGQCVIub1SUlp" LanguageVersion="2021.4.0.55" Version="0.128">
-  <NugetDependency Id="QNDaxjZxapFM8KPBDLuO6H" Location="VL.CoreLib" Version="2021.4.0-0055-g3e2beca9a4" />
+<Document xmlns:p="property" Id="IeOwK5mcmYGQCVIub1SUlp" LanguageVersion="2021.4.0.67" Version="0.128">
+  <NugetDependency Id="QNDaxjZxapFM8KPBDLuO6H" Location="VL.CoreLib" Version="2021.4.0-0067-g19ccee761f" />
   <Patch Id="G28kmfwtWsRPWb67PHzP5Y">
     <Canvas Id="TtPf6YeHIWxLlrjYVAmnpJ" DefaultCategory="Stride" CanvasType="FullCategory">
       <Canvas Id="I05FXKkjOcbLjpHeuJvntb" Name="Experimental" Position="214,241">
@@ -8890,12 +8890,11 @@
                       </p:Interfaces>
                       <Patch Id="OhgxFpUAeD3MKIOZR9oPqH" IsGeneric="true">
                         <Canvas Id="P9tfWsXSC1RM8eQ06kx6Eg" CanvasType="Group">
-                          <ControlPoint Id="G9xH2EnvnJNMjBlG6Bjd2j" Bounds="319,-40" />
                           <ControlPoint Id="PTpMIP6aQEhNajyTGvO0AJ" Bounds="649,64" />
                           <ControlPoint Id="Vtqyi3XavaEOIzoMhZkovb" Bounds="472,79" />
                           <Pad Id="Tnovjq9e9zdNWFga0MUNcb" SlotId="VJIGmMhuFfONM1ml0tt3uZ" Bounds="649,108" />
                           <Pad Id="CWdueLCbDkXLODhVO4VLOu" SlotId="Ouo4g9HpSe7OsrhvvuLVCJ" Bounds="325,401" />
-                          <ControlPoint Id="I0eORpIxCEzQd1Y2mpuGa7" Bounds="411,366" />
+                          <ControlPoint Id="I0eORpIxCEzQd1Y2mpuGa7" Bounds="430,415" />
                           <Node Bounds="470,148,115,19" Id="BxyemsltLl8LsjMhgNkjL9">
                             <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -8936,35 +8935,40 @@
                               </Node>
                             </Patch>
                           </Node>
-                          <Node Bounds="322,472,88,26" Id="DPCdgDtEVVHLxDlakr7ooA">
-                            <p:NodeReference LastCategoryFullName="Stride.Rendering.ParameterCollection" LastSymbolSource="Stride.dll">
-                              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                              <Choice Kind="OperationCallFlag" Name="Set" />
-                              <CategoryReference Kind="AssemblyCategory" Name="ParameterCollection" NeedsToBeDirectParent="true" />
-                              <PinReference Kind="InputPin" Name="Value" />
-                              <PinReference Kind="InputPin" Name="Parameter">
-                                <p:DataTypeReference p:Type="TypeReference" LastCategoryFullName="Stride.Rendering" LastSymbolSource="Stride.dll">
-                                  <Choice Kind="TypeFlag" Name="ValueParameterKey`1" />
-                                  <p:TypeArguments>
-                                    <TypeParameterReference />
-                                  </p:TypeArguments>
-                                </p:DataTypeReference>
-                              </PinReference>
+                          <ControlPoint Id="BpEOlw9AJ2AN4jwoVD8wzr" Bounds="323,81" />
+                          <Node Bounds="311,454,113,86" Id="P6FVjqScpq8PNGJKWthcAP">
+                            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                              <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                              <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
+                              <CategoryReference Kind="Category" Name="Primitive" />
                             </p:NodeReference>
-                            <Pin Id="SJuGb06UzNUMiLv37TAk6M" Name="Input" Kind="StateInputPin" />
-                            <Pin Id="GJ92sz98jdqM29ebkqH8Hu" Name="Parameter" Kind="InputPin" />
-                            <Pin Id="NkBDMTMYrrOMsTiUkT6l4Y" Name="Value" Kind="InputPin" />
-                            <Pin Id="NL4KRqghwS7PiqCeaf8p02" Name="Output" Kind="StateOutputPin" />
-                            <Pin Id="UCjZgttYQMzMCaGqnY2JBW" Name="Apply" Kind="InputPin" />
-                          </Node>
-                          <Node Bounds="405,429,65,19" Id="LxpuIGqgbYmLNqpXKLqzjj">
-                            <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl">
-                              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                              <Choice Kind="OperationCallFlag" Name="IsAssigned" />
-                            </p:NodeReference>
-                            <Pin Id="HRu7AVy15EXLXdiSr3cIoc" Name="X" Kind="InputPin" />
-                            <Pin Id="FudJiJ21rhCM5QjKP3q6Nn" Name="Result" Kind="OutputPin" />
-                            <Pin Id="DO1RcEgFwbqO4E2FVX0H8N" Name="Not Assigned" Kind="OutputPin" />
+                            <Pin Id="OjY2GqDqm39QERIlX5ML4u" Name="Break" Kind="OutputPin" />
+                            <Patch Id="Pvor6Wjq3FYPdbP4X5F7hX" ManuallySortedPins="true">
+                              <Patch Id="QOvMKrqzAdeN9J4aY5wZE5" Name="Create" ManuallySortedPins="true" />
+                              <Patch Id="SQPmA26LUisLVeZdMaCrCF" Name="Update" ManuallySortedPins="true" />
+                              <Patch Id="R3YT4nPetUcO4CVejLcPGW" Name="Dispose" ManuallySortedPins="true" />
+                              <Node Bounds="324,479,88,26" Id="DPCdgDtEVVHLxDlakr7ooA">
+                                <p:NodeReference LastCategoryFullName="Stride.Rendering.ParameterCollection" LastSymbolSource="Stride.dll">
+                                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                  <Choice Kind="OperationCallFlag" Name="Set" />
+                                  <CategoryReference Kind="AssemblyCategory" Name="ParameterCollection" NeedsToBeDirectParent="true" />
+                                  <PinReference Kind="InputPin" Name="Value" />
+                                  <PinReference Kind="InputPin" Name="Parameter">
+                                    <p:DataTypeReference p:Type="TypeReference" LastCategoryFullName="Stride.Rendering" LastSymbolSource="Stride.dll">
+                                      <Choice Kind="TypeFlag" Name="ValueParameterKey`1" />
+                                      <p:TypeArguments>
+                                        <TypeParameterReference />
+                                      </p:TypeArguments>
+                                    </p:DataTypeReference>
+                                  </PinReference>
+                                </p:NodeReference>
+                                <Pin Id="SJuGb06UzNUMiLv37TAk6M" Name="Input" Kind="StateInputPin" />
+                                <Pin Id="GJ92sz98jdqM29ebkqH8Hu" Name="Parameter" Kind="InputPin" />
+                                <Pin Id="NkBDMTMYrrOMsTiUkT6l4Y" Name="Value" Kind="InputPin" />
+                                <Pin Id="NL4KRqghwS7PiqCeaf8p02" Name="Output" Kind="StateOutputPin" />
+                              </Node>
+                            </Patch>
+                            <ControlPoint Id="BXiAjc8bZwVPNTk1KlddcL" Bounds="325,460" Alignment="Top" />
                           </Node>
                         </Canvas>
                         <ProcessDefinition Id="Lr2r52JeOnALK8FH2Rh7Jl" HasStateOut="true">
@@ -8972,7 +8976,6 @@
                           <Fragment Id="CHKUtF7sABaMEqdjVC6g4r" Patch="VrRtK2VcddfMPuw1U6DeZH" Enabled="true" />
                           <Fragment Id="GVBP909ccK0MibUcSebQGN" Patch="RPVpk2jSi7WQUPI341Qvp5" />
                         </ProcessDefinition>
-                        <Link Id="MJk8DDqMMvXMeCbHepWAhU" Ids="CJTLrE78nhiNVV4TgYeqYR,G9xH2EnvnJNMjBlG6Bjd2j" IsHidden="true" />
                         <Link Id="SWV9qd45JlaNtX6bZgapFl" Ids="FmEjmp1xXJPP5ahMmEd83P,PTpMIP6aQEhNajyTGvO0AJ" IsHidden="true" />
                         <Link Id="AonhKHwnQEqPMKS33SLqPS" Ids="Hw0NZZYLGiyMrgs3oYj8Uw,Vtqyi3XavaEOIzoMhZkovb" IsHidden="true" />
                         <Link Id="NSNkDeTW61EQZWIQzCf2tC" Ids="Vtqyi3XavaEOIzoMhZkovb,NgbQzCOEcrzLlRyssA6fFt" />
@@ -8981,6 +8984,12 @@
                         <Link Id="N1xlUVIR14HPq3ALfNSavJ" Ids="Tnovjq9e9zdNWFga0MUNcb,L9mTEg0QxFQNn7FP8VZY9d" />
                         <Slot Id="Ouo4g9HpSe7OsrhvvuLVCJ" Name="Parameters" />
                         <Link Id="BmmNSbOlR4gQSXAjNGg1Sl" Ids="SZDcbIMJYTWPyT0wM6v7JL,I0eORpIxCEzQd1Y2mpuGa7" IsHidden="true" />
+                        <Link Id="CDDfEApdcPILXAxDo0Gjjh" Ids="LZ9E4wqO52aOngAzbe0IKl,UcAU4gpHMHHMOstz6OfUlD" />
+                        <Link Id="FFR83447bavNm47VtHqW59" Ids="SqEdFlVfR8CNhCp0EC4eJo,JVaYRCoe0k0PPnhIWgnf1A" />
+                        <Link Id="PldS8HpwcGyPSw0LT7S4VJ" Ids="JVaYRCoe0k0PPnhIWgnf1A,SyxunaDve8LO2xEa1SrKtz" />
+                        <Link Id="HJ3DRAMaQu3OnRHi1V74wg" Ids="JD2Oa6OqiUYP7TSvydNCfa,JcwiMKpACURNPGFNow4UNf" />
+                        <Link Id="SqaCi5mX9uuMPPRDfjSDpn" Ids="JcwiMKpACURNPGFNow4UNf,GJ92sz98jdqM29ebkqH8Hu" />
+                        <Link Id="FtInTFvH3dSNwN4WQhtyB4" Ids="I0eORpIxCEzQd1Y2mpuGa7,NkBDMTMYrrOMsTiUkT6l4Y" />
                         <Patch Id="RYELl5BbxwLODacziWWBa2" Name="Create">
                           <Pin Id="FmEjmp1xXJPP5ahMmEd83P" Name="Name" Kind="InputPin" />
                         </Patch>
@@ -8988,23 +8997,13 @@
                           <Pin Id="SZDcbIMJYTWPyT0wM6v7JL" Name="Value" Kind="InputPin" Bounds="698,344" />
                         </Patch>
                         <Patch Id="RPVpk2jSi7WQUPI341Qvp5" Name="SetAcessor">
-                          <Pin Id="CJTLrE78nhiNVV4TgYeqYR" MergeId="613739" Name="Parameters" Kind="InputPin">
-                            <p:TypeAnnotation>
-                              <Choice Kind="TypeFlag" Name="ParameterCollection" />
-                            </p:TypeAnnotation>
-                          </Pin>
+                          <Pin Id="Tn5wohJmav2O1bOrStPN0J" Name="Parameter Collections" Kind="InputPin" />
                           <Pin Id="Hw0NZZYLGiyMrgs3oYj8Uw" Name="Class Name" Kind="InputPin" />
                         </Patch>
-                        <Link Id="CDDfEApdcPILXAxDo0Gjjh" Ids="LZ9E4wqO52aOngAzbe0IKl,UcAU4gpHMHHMOstz6OfUlD" />
-                        <Link Id="FFR83447bavNm47VtHqW59" Ids="SqEdFlVfR8CNhCp0EC4eJo,JVaYRCoe0k0PPnhIWgnf1A" />
-                        <Link Id="PldS8HpwcGyPSw0LT7S4VJ" Ids="JVaYRCoe0k0PPnhIWgnf1A,SyxunaDve8LO2xEa1SrKtz" />
-                        <Link Id="HJ3DRAMaQu3OnRHi1V74wg" Ids="JD2Oa6OqiUYP7TSvydNCfa,JcwiMKpACURNPGFNow4UNf" />
-                        <Link Id="SqaCi5mX9uuMPPRDfjSDpn" Ids="JcwiMKpACURNPGFNow4UNf,GJ92sz98jdqM29ebkqH8Hu" />
-                        <Link Id="P5DqJxPU7xVLsLElUefJO7" Ids="CWdueLCbDkXLODhVO4VLOu,HRu7AVy15EXLXdiSr3cIoc" />
-                        <Link Id="FtInTFvH3dSNwN4WQhtyB4" Ids="I0eORpIxCEzQd1Y2mpuGa7,NkBDMTMYrrOMsTiUkT6l4Y" />
-                        <Link Id="QSAgQCfiJSrO2twfHSLYJn" Ids="FudJiJ21rhCM5QjKP3q6Nn,UCjZgttYQMzMCaGqnY2JBW" />
-                        <Link Id="HemN8kfWKUINQxDwxY4fwS" Ids="CWdueLCbDkXLODhVO4VLOu,SJuGb06UzNUMiLv37TAk6M" />
-                        <Link Id="BAnFpXSiXMTOj8smPwzmDy" Ids="G9xH2EnvnJNMjBlG6Bjd2j,CWdueLCbDkXLODhVO4VLOu" />
+                        <Link Id="MUUUW4oYTsaPwX2k2RDWQj" Ids="Tn5wohJmav2O1bOrStPN0J,BpEOlw9AJ2AN4jwoVD8wzr" IsHidden="true" />
+                        <Link Id="QDdTjj1VT7uMaOLvjmsezN" Ids="BpEOlw9AJ2AN4jwoVD8wzr,CWdueLCbDkXLODhVO4VLOu" />
+                        <Link Id="Rq7cz7utDzJPd1tGE4ZY4B" Ids="CWdueLCbDkXLODhVO4VLOu,BXiAjc8bZwVPNTk1KlddcL" />
+                        <Link Id="UIF2PsWjDoLPasxodVPDLt" Ids="BXiAjc8bZwVPNTk1KlddcL,SJuGb06UzNUMiLv37TAk6M" />
                       </Patch>
                     </Node>
                     <!--
@@ -9018,16 +9017,21 @@
                       </p:NodeReference>
                       <Patch Id="C9jcxndveVAOrfpz4iYNiR">
                         <Canvas Id="UiNFxllAHC8LUhHht8ykYG" CanvasType="Group">
-                          <ControlPoint Id="QfZLfyKUvrkQSKGQZAJL2Y" Bounds="469,188" />
+                          <ControlPoint Id="QfZLfyKUvrkQSKGQZAJL2Y" Bounds="406,189" />
                           <ControlPoint Id="EH5PmVehQcFOhvlKa0hwqN" Bounds="549,189" />
                         </Canvas>
                         <ProcessDefinition Id="BUgLRhik344P9eEUoEvWtF" IsHidden="true">
                           <Fragment Id="Hxznh3qjlZ2OP4QBnbGvEn" Patch="E8PXJYvqTjoO8Vn9Kgb0Zc" />
                         </ProcessDefinition>
                         <Patch Id="E8PXJYvqTjoO8Vn9Kgb0Zc" Name="SetAcessor">
-                          <Pin Id="DfqFBz1Zy0FM4AcGtLxAct" Name="Parameters" Kind="InputPin">
+                          <Pin Id="DfqFBz1Zy0FM4AcGtLxAct" Name="Parameter Collections" Kind="InputPin">
                             <p:TypeAnnotation>
-                              <Choice Kind="TypeFlag" Name="ParameterCollection" />
+                              <Choice Kind="TypeFlag" Name="Array" />
+                              <p:TypeArguments>
+                                <TypeReference>
+                                  <Choice Kind="TypeFlag" Name="ParameterCollection" />
+                                </TypeReference>
+                              </p:TypeArguments>
                             </p:TypeAnnotation>
                           </Pin>
                           <Pin Id="M2J3TB7xZnrNkgjb244ovG" Name="Class Name" Kind="InputPin">
@@ -9057,21 +9061,11 @@
                       </p:Interfaces>
                       <Patch Id="CoYcO5LzSjNP02iDOPSiHy" IsGeneric="true">
                         <Canvas Id="VGIf5mAeLQmL2wHkv97yPd" CanvasType="Group">
-                          <ControlPoint Id="BlSFsrXaOaEMhYZvUEs7Jk" Bounds="326,216" />
                           <ControlPoint Id="Tuca5vHJQ3zNDcJEgvscn3" Bounds="668,170" />
                           <ControlPoint Id="LRSmySNSTKWLG6fyQP7ukp" Bounds="504,201" />
                           <Pad Id="UkhxfpgrWIwLcHjrasVVyc" SlotId="GGwYKdT9nzsMsrXucIf1UA" Bounds="668,214" />
                           <Pad Id="BpSbOM58gKxMY2DB3Wg9sZ" SlotId="QjtvU6YYZ9dLJCEWoQvWZA" Bounds="326,441" />
                           <ControlPoint Id="F8M2EFKHxkJQBYPuptS4Hj" Bounds="677,360" />
-                          <Node Bounds="407,475,65,19" Id="JC9wvmbRkjVNPAYYvCtrb2">
-                            <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl">
-                              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                              <Choice Kind="OperationCallFlag" Name="IsAssigned" />
-                            </p:NodeReference>
-                            <Pin Id="JsmOujhRPOCP9LBBFNrUJm" Name="X" Kind="InputPin" />
-                            <Pin Id="BUywJgCak2ZOEpFYN7Qedr" Name="Result" Kind="OutputPin" />
-                            <Pin Id="BGutlSmrytMM4dpfnePDE6" Name="Not Assigned" Kind="OutputPin" />
-                          </Node>
                           <Node Bounds="501,266,115,19" Id="Pjh43cWLfCMPHMtb7EsvaP">
                             <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -9112,26 +9106,40 @@
                               </Node>
                             </Patch>
                           </Node>
-                          <Node Bounds="324,514,88,26" Id="BScIakEe8AJQRmfXhbUR9q">
-                            <p:NodeReference LastCategoryFullName="Stride.Rendering.ParameterCollection" LastSymbolSource="Stride.dll">
-                              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                              <Choice Kind="OperationCallFlag" Name="Set" />
-                              <CategoryReference Kind="AssemblyCategory" Name="ParameterCollection" NeedsToBeDirectParent="true" />
-                              <PinReference Kind="InputPin" Name="Value" />
-                              <PinReference Kind="InputPin" Name="Parameter">
-                                <p:DataTypeReference p:Type="TypeReference" LastCategoryFullName="Stride.Rendering" LastSymbolSource="Stride.dll">
-                                  <Choice Kind="TypeFlag" Name="ObjectParameterKey`1" />
-                                  <p:TypeArguments>
-                                    <TypeParameterReference />
-                                  </p:TypeArguments>
-                                </p:DataTypeReference>
-                              </PinReference>
+                          <ControlPoint Id="GHsJMV8hUu2PYFZGXp1J4e" Bounds="326,246" />
+                          <Node Bounds="311,506,112,86" Id="ANTQcAXREaFOE47JqpaM8b">
+                            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                              <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                              <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
+                              <CategoryReference Kind="Category" Name="Primitive" />
                             </p:NodeReference>
-                            <Pin Id="HzcdKU3IjU6Pntummq4dea" Name="Input" Kind="StateInputPin" />
-                            <Pin Id="KYoQDUpNBP5QHdGLZQ4L4m" Name="Parameter" Kind="InputPin" />
-                            <Pin Id="LJSvT4VkR4HQOMMfJGsjru" Name="Value" Kind="InputPin" />
-                            <Pin Id="Rz8VdCruDKNL4ZQZ1XzI9l" Name="Output" Kind="StateOutputPin" />
-                            <Pin Id="OP5eDvTEtG1Nlwf4f5KfjQ" Name="Apply" Kind="InputPin" />
+                            <Pin Id="Cf3pE0JiYq1LOZ6Sj02QfH" Name="Break" Kind="OutputPin" />
+                            <Patch Id="LCmBA9YJuB6NpArc0HpFzk" ManuallySortedPins="true">
+                              <Patch Id="OGDA6sAShR1NETB1v2qSZz" Name="Create" ManuallySortedPins="true" />
+                              <Patch Id="OPnC6OvvLo3PNfBalnmDJV" Name="Update" ManuallySortedPins="true" />
+                              <Patch Id="Va47ZkXTRgqMRz35KwEV7d" Name="Dispose" ManuallySortedPins="true" />
+                              <Node Bounds="323,536,88,26" Id="BScIakEe8AJQRmfXhbUR9q">
+                                <p:NodeReference LastCategoryFullName="Stride.Rendering.ParameterCollection" LastSymbolSource="Stride.dll">
+                                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                  <Choice Kind="OperationCallFlag" Name="Set" />
+                                  <CategoryReference Kind="AssemblyCategory" Name="ParameterCollection" NeedsToBeDirectParent="true" />
+                                  <PinReference Kind="InputPin" Name="Value" />
+                                  <PinReference Kind="InputPin" Name="Parameter">
+                                    <p:DataTypeReference p:Type="TypeReference" LastCategoryFullName="Stride.Rendering" LastSymbolSource="Stride.dll">
+                                      <Choice Kind="TypeFlag" Name="ObjectParameterKey`1" />
+                                      <p:TypeArguments>
+                                        <TypeParameterReference />
+                                      </p:TypeArguments>
+                                    </p:DataTypeReference>
+                                  </PinReference>
+                                </p:NodeReference>
+                                <Pin Id="HzcdKU3IjU6Pntummq4dea" Name="Input" Kind="StateInputPin" />
+                                <Pin Id="KYoQDUpNBP5QHdGLZQ4L4m" Name="Parameter" Kind="InputPin" />
+                                <Pin Id="LJSvT4VkR4HQOMMfJGsjru" Name="Value" Kind="InputPin" />
+                                <Pin Id="Rz8VdCruDKNL4ZQZ1XzI9l" Name="Output" Kind="StateOutputPin" />
+                              </Node>
+                            </Patch>
+                            <ControlPoint Id="VCZ45QRn5JfLYkUjkJgAFr" Bounds="325,512" Alignment="Top" />
                           </Node>
                         </Canvas>
                         <ProcessDefinition Id="LnAXwKJewjxNxjbFf0DXgt" HasStateOut="true">
@@ -9139,7 +9147,6 @@
                           <Fragment Id="P36fRwMyYIELeL7s9QUBLJ" Patch="COoARysoPGTMoAzHO2Hmyj" Enabled="true" />
                           <Fragment Id="BDUXWvSkuizMTgyVDqYOhP" Patch="PnMJcwEeeMQMRRHaqN32in" />
                         </ProcessDefinition>
-                        <Link Id="IjNEIK50zwvN4mHupBpbDX" Ids="KDljBQ4TedaMjvxK4QqIu5,BlSFsrXaOaEMhYZvUEs7Jk" IsHidden="true" />
                         <Link Id="GrWXXOiydPcLKWsZpumMEt" Ids="UZ4xa6Q8eUaNj5XRopMIqg,Tuca5vHJQ3zNDcJEgvscn3" IsHidden="true" />
                         <Link Id="SZOiyy3XCVxQCYV0SWZcgF" Ids="QELRWXR946MPFV7cxOQoVj,LRSmySNSTKWLG6fyQP7ukp" IsHidden="true" />
                         <Link Id="MdtYql2YTzlQTvF4Cc0Wjn" Ids="LRSmySNSTKWLG6fyQP7ukp,Cs6eW4LLeMNQJgpOLycSIu" />
@@ -9148,6 +9155,12 @@
                         <Link Id="MY0Om6VBdmYOceQoB2OBf5" Ids="UkhxfpgrWIwLcHjrasVVyc,SDpKkgRfhfxQFeji2lv6Oz" />
                         <Slot Id="QjtvU6YYZ9dLJCEWoQvWZA" Name="Parameters" />
                         <Link Id="Mzg98V1OTJNLzZRLadUGpv" Ids="N59qhH2jVV8M7B8CqTQ6N1,F8M2EFKHxkJQBYPuptS4Hj" IsHidden="true" />
+                        <Link Id="BPg2Vmcu7fGOYwYHEM56wP" Ids="UYYisR1lxOeP8QBLit73mz,KNMn3WkjqlBMlvXh3GyRKS" />
+                        <Link Id="QIntcONo12ML9j4sIGu00J" Ids="QwvogM522tsMwgbQ5qzDYD,F07Gd3RZLWbL2h4bMweDsL" />
+                        <Link Id="UkAmJArRpmMM46UBK5uLf5" Ids="F07Gd3RZLWbL2h4bMweDsL,Aizh2iWwEKoMX3eRwZjY46" />
+                        <Link Id="IRlVWPBiEhgNJPrL8TvKJ2" Ids="KC80zMWAEOvMcKwmvIVoX5,TXjlg0UA5M9P7ks2IJpp3X" />
+                        <Link Id="MFqdn4fIb1bP0Od4Cy4fLV" Ids="F8M2EFKHxkJQBYPuptS4Hj,LJSvT4VkR4HQOMMfJGsjru" />
+                        <Link Id="VZQG4Z8rwJKPeCutfE2UZp" Ids="TXjlg0UA5M9P7ks2IJpp3X,KYoQDUpNBP5QHdGLZQ4L4m" />
                         <Patch Id="EjWog3ckE3oPr9QmOdKcNo" Name="Create">
                           <Pin Id="UZ4xa6Q8eUaNj5XRopMIqg" Name="Name" Kind="InputPin" />
                         </Patch>
@@ -9155,23 +9168,13 @@
                           <Pin Id="N59qhH2jVV8M7B8CqTQ6N1" Name="Value" Kind="InputPin" Bounds="698,344" />
                         </Patch>
                         <Patch Id="PnMJcwEeeMQMRRHaqN32in" Name="SetAcessor">
-                          <Pin Id="KDljBQ4TedaMjvxK4QqIu5" MergeId="613739" Name="Parameters" Kind="InputPin">
-                            <p:TypeAnnotation>
-                              <Choice Kind="TypeFlag" Name="ParameterCollection" />
-                            </p:TypeAnnotation>
-                          </Pin>
+                          <Pin Id="Uy4xfBdbCp9Nb0upnahNKR" Name="Parameter Collections" Kind="InputPin" />
                           <Pin Id="QELRWXR946MPFV7cxOQoVj" Name="Class Name" Kind="InputPin" />
                         </Patch>
-                        <Link Id="SuyDDZu2KoiL7mJ8Dw5HwI" Ids="BpSbOM58gKxMY2DB3Wg9sZ,JsmOujhRPOCP9LBBFNrUJm" />
-                        <Link Id="BPg2Vmcu7fGOYwYHEM56wP" Ids="UYYisR1lxOeP8QBLit73mz,KNMn3WkjqlBMlvXh3GyRKS" />
-                        <Link Id="QIntcONo12ML9j4sIGu00J" Ids="QwvogM522tsMwgbQ5qzDYD,F07Gd3RZLWbL2h4bMweDsL" />
-                        <Link Id="UkAmJArRpmMM46UBK5uLf5" Ids="F07Gd3RZLWbL2h4bMweDsL,Aizh2iWwEKoMX3eRwZjY46" />
-                        <Link Id="IRlVWPBiEhgNJPrL8TvKJ2" Ids="KC80zMWAEOvMcKwmvIVoX5,TXjlg0UA5M9P7ks2IJpp3X" />
-                        <Link Id="VoqSwCszWxwMePPdF7saiW" Ids="BUywJgCak2ZOEpFYN7Qedr,OP5eDvTEtG1Nlwf4f5KfjQ" />
-                        <Link Id="MFqdn4fIb1bP0Od4Cy4fLV" Ids="F8M2EFKHxkJQBYPuptS4Hj,LJSvT4VkR4HQOMMfJGsjru" />
-                        <Link Id="VZQG4Z8rwJKPeCutfE2UZp" Ids="TXjlg0UA5M9P7ks2IJpp3X,KYoQDUpNBP5QHdGLZQ4L4m" />
-                        <Link Id="T52bMvtEUfsML8QNgPyAAE" Ids="BpSbOM58gKxMY2DB3Wg9sZ,HzcdKU3IjU6Pntummq4dea" />
-                        <Link Id="LY5DPzkvihWMFSOtDJ07bM" Ids="BlSFsrXaOaEMhYZvUEs7Jk,BpSbOM58gKxMY2DB3Wg9sZ" />
+                        <Link Id="CqgX6CJBLgWMxpX5NSjUpE" Ids="Uy4xfBdbCp9Nb0upnahNKR,GHsJMV8hUu2PYFZGXp1J4e" IsHidden="true" />
+                        <Link Id="RWUpkJrkDFUPn2wQa4tDkb" Ids="GHsJMV8hUu2PYFZGXp1J4e,BpSbOM58gKxMY2DB3Wg9sZ" />
+                        <Link Id="VCRYco6aMuiMtUh0x1xxPp" Ids="VCZ45QRn5JfLYkUjkJgAFr,HzcdKU3IjU6Pntummq4dea" />
+                        <Link Id="Dmgwz1BDdXmNAOCoCONvCe" Ids="BpSbOM58gKxMY2DB3Wg9sZ,VCZ45QRn5JfLYkUjkJgAFr" />
                       </Patch>
                     </Node>
                     <!--
@@ -9189,140 +9192,133 @@
                             <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.GenericComputeNode" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="ClassType" Name="GenericComputeNode" />
-                              <Choice Kind="OperationCallFlag" Name="Parameters" />
+                              <Choice Kind="OperationCallFlag" Name="ParameterCollections" />
                             </p:NodeReference>
                             <Pin Id="Ri8eMQbu8yBQVLhOFX1hVy" Name="Input" Kind="StateInputPin" />
                             <Pin Id="Uo6iic2QVdHPYP5YusNHni" Name="Output" Kind="StateOutputPin" />
-                            <Pin Id="RiSEEux85pENA7r4VUm5eI" Name="Parameters" Kind="OutputPin" />
+                            <Pin Id="DMV7eV3VMYlOKcwX69qWF6" Name="Parameter Collections" Kind="OutputPin" />
                           </Node>
-                          <Node Bounds="593,296,65,19" Id="N83vSlHSdbOLn4WTn9xgGo">
-                            <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl">
-                              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                              <Choice Kind="OperationCallFlag" Name="IsAssigned" />
-                            </p:NodeReference>
-                            <Pin Id="MPmzhKIkAmyLlJcpjEW1Oe" Name="X" Kind="InputPin" />
-                            <Pin Id="S7AO8IPIKzSPbtEoO9XMZ5" Name="Result" Kind="OutputPin" />
-                            <Pin Id="TIwXxad4aVzPnmi9utvELR" Name="Not Assigned" Kind="OutputPin" />
-                          </Node>
-                          <Node Bounds="593,344,356,520" Id="GCxYnxNsnv5LvM8iJnVI2i">
+                          <ControlPoint Id="Eq3CKDhmr8YPqqnjmyboAM" Bounds="651,206" />
+                          <ControlPoint Id="HIe6FtIFXUVLEgo6kmc8UQ" Bounds="985,538" />
+                          <Node Bounds="593,355,356,520" Id="AsL4SKdAZkdNbFWArtJ1Hb">
                             <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
                               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                              <Choice Kind="ApplicationStatefulRegion" Name="If" />
-                              <FullNameCategoryReference ID="Primitive" />
+                              <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
+                              <CategoryReference Kind="Category" Name="Primitive" />
                             </p:NodeReference>
-                            <Pin Id="SfFBOemzHRJPXwfUGsHL5J" Name="Condition" Kind="InputPin" />
-                            <Patch Id="SgiKY1rgFZVO26tyEzp2yU" ManuallySortedPins="true">
-                              <Patch Id="Ph4kF4qLVabL754i3iokGr" Name="Create" ManuallySortedPins="true" />
-                              <Patch Id="OxldxCsmiLMMICfmSBjoOj" Name="Then" ManuallySortedPins="true" />
-                              <Node Bounds="637,412,300,432" Id="I7c08PMeUhQOzQt1Vq65u2">
+                            <Pin Id="CAPUOx5Iv5RLKXbuGxTsEZ" Name="Break" Kind="OutputPin" />
+                            <Patch Id="TVzex4Qo9WHMvNaJb8U9Ze" ManuallySortedPins="true">
+                              <Patch Id="J9EubbVQDIdMzNaR7ENd3I" Name="Create" ManuallySortedPins="true" />
+                              <Patch Id="RpAnTa8GRSeQa90SYAAwve" Name="Update" ManuallySortedPins="true" />
+                              <Patch Id="RzLSlU7zdpONCMHIWNET63" Name="Dispose" ManuallySortedPins="true" />
+                              <Node Bounds="637,424,300,432" Id="UYUQj1TrF2jOvJRzAmVF7q">
                                 <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
                                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                   <Choice Kind="ProcessStatefulRegion" Name="Cache" />
                                   <FullNameCategoryReference ID="Primitive" />
                                 </p:NodeReference>
-                                <Pin Id="MJIJ6rHfnS0MrMbxn0wcYG" Name="Force" Kind="InputPin" DefaultValue="False">
+                                <Pin Id="NxTbR42WbODQQjIkTYBgNE" Name="Force" Kind="InputPin" DefaultValue="False">
                                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                                     <Choice Kind="TypeFlag" Name="Boolean" />
                                   </p:TypeAnnotation>
                                 </Pin>
-                                <Pin Id="LVDHgGDQfinMID62ZPisbG" Name="Dispose Cached Outputs" Kind="InputPin" />
-                                <Pin Id="TzLyLO6SJY9MuVLPyJJji0" Name="Has Changed" Kind="OutputPin" />
-                                <ControlPoint Id="AasBbT66zgHQdQ8BbZQLuU" Bounds="795,419" Alignment="Top" />
-                                <ControlPoint Id="D2THoxoo8f1Py66njRYuKc" Bounds="877,419" Alignment="Top" />
-                                <Patch Id="UMOP1fKcKfBLiibQ1snaLL" ManuallySortedPins="true">
-                                  <Patch Id="KzsNHFxj9LLM49T5mFpU0o" Name="Create" ManuallySortedPins="true" />
-                                  <Patch Id="MjXHYuVMbdiORflB1I7l31" Name="Then" ManuallySortedPins="true" />
-                                  <Node Bounds="649,436,94,26" Id="KnYinaNh0VTNptkmKKxdIL">
+                                <Pin Id="UhoPJviqIeyM8EFigPbZ5c" Name="Dispose Cached Outputs" Kind="InputPin" />
+                                <Pin Id="OULoOKcHAzhQV3Ibd5UAhR" Name="Has Changed" Kind="OutputPin" />
+                                <ControlPoint Id="DgSzUfagjawM1T6R8YNsXC" Bounds="795,430" Alignment="Top" />
+                                <ControlPoint Id="EhMbkXOnirILTjbaRTUoY5" Bounds="877,430" Alignment="Top" />
+                                <Patch Id="NPqLUQe2vosPTC1LSn6WH0" ManuallySortedPins="true">
+                                  <Patch Id="UO9QL1uzBDdM6avDYPn6nc" Name="Create" ManuallySortedPins="true" />
+                                  <Patch Id="T4kOMBYnHpbMs0LXLwI2gN" Name="Then" ManuallySortedPins="true" />
+                                  <Node Bounds="649,447,94,26" Id="H8hXtZgseCMNsQNnoTEJeG">
                                     <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX.GenericComputeNode" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <CategoryReference Kind="ClassType" Name="GenericComputeNode" />
                                       <Choice Kind="OperationCallFlag" Name="ShaderClass" />
                                     </p:NodeReference>
-                                    <Pin Id="ElDjCfYG85cOMlJoM0t6cp" Name="Input" Kind="StateInputPin" />
-                                    <Pin Id="ABJTDZk5t1tPr2olD33ykl" Name="Output" Kind="StateOutputPin" />
-                                    <Pin Id="MY6Wfl3gsIYL3SuJ4Y1Wj3" Name="Shader Class" Kind="OutputPin" />
+                                    <Pin Id="SQMm00WiVyBQFDqHXZqLuY" Name="Input" Kind="StateInputPin" />
+                                    <Pin Id="E1Q4zBjKpZPQassf96UmEV" Name="Output" Kind="StateOutputPin" />
+                                    <Pin Id="VEVzAsIq9p2MJFnRN13Iqa" Name="Shader Class" Kind="OutputPin" />
                                   </Node>
-                                  <Node Bounds="711,538,214,286" Id="EcNZaMSVPEUMDERiDTmqIx">
+                                  <Node Bounds="711,549,214,286" Id="UkWCLi0L0lcMnXuEQPFGi1">
                                     <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
                                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                       <Choice Kind="ApplicationStatefulRegion" Name="If" />
                                       <FullNameCategoryReference ID="Primitive" />
                                     </p:NodeReference>
-                                    <Pin Id="TCZywqsD2AFOzYY7GJeerW" Name="Condition" Kind="InputPin" />
-                                    <Patch Id="N6m4H6sCuWGPINqEiiruxx" ManuallySortedPins="true">
-                                      <Patch Id="MEPI6IUCuUPMl8YxQck47W" Name="Create" ManuallySortedPins="true" />
-                                      <Patch Id="OBiE8YbRPHqLYF351dskl6" Name="Then" ManuallySortedPins="true" />
-                                      <Node Bounds="740,561,78,26" Id="CflwdzHI77IOCaK80Da1I6">
+                                    <Pin Id="QZVW6N11GXSOOKkJWoR2mQ" Name="Condition" Kind="InputPin" />
+                                    <Patch Id="MTZomhjK0VjP34sJq8eydc" ManuallySortedPins="true">
+                                      <Patch Id="LajAJKgLcVfMOcYkwwlJUr" Name="Create" ManuallySortedPins="true" />
+                                      <Patch Id="F3unajeHnefOLdaY0jhmPf" Name="Then" ManuallySortedPins="true" />
+                                      <Node Bounds="740,572,78,26" Id="VNkRzpCUwL2LfCqPg4V2c5">
                                         <p:NodeReference LastCategoryFullName="Stride.API.Shaders.ShaderClassCode" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl">
                                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                           <CategoryReference Kind="ClassType" Name="ShaderClassCode" />
                                           <Choice Kind="OperationCallFlag" Name="ClassName" />
                                         </p:NodeReference>
-                                        <Pin Id="DkyETjMmz8LLJ5TyPuu3fM" Name="Input" Kind="StateInputPin" />
-                                        <Pin Id="LA6RKtrSJGxMzoqLOmr3UZ" Name="Output" Kind="StateOutputPin" />
-                                        <Pin Id="Sgp1j9OIjawMDkb2MJimmB" Name="Class Name" Kind="OutputPin" />
+                                        <Pin Id="GgpCwtoh5z2LWQ2WW7KnWN" Name="Input" Kind="StateInputPin" />
+                                        <Pin Id="K6HiD5NdU3ZNnxKpaohgxo" Name="Output" Kind="StateOutputPin" />
+                                        <Pin Id="RJrIZ59buKOLYT19CDvbFt" Name="Class Name" Kind="OutputPin" />
                                       </Node>
-                                      <Node Bounds="763,656,150,148" Id="MbzkWJiZX2jOrOryiFqRqj">
+                                      <Node Bounds="763,668,150,148" Id="Fjuoeh3nAj3QDRUBJcFGjy">
                                         <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
                                           <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                           <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
                                           <CategoryReference Kind="Category" Name="Primitive" />
                                         </p:NodeReference>
-                                        <Pin Id="KNHYwdeOMiQMmXPx7PRNly" Name="Break" Kind="OutputPin" />
-                                        <ControlPoint Id="HoVpnixLykLOC0Etq7KYmL" Bounds="777,663" Alignment="Top" />
-                                        <Patch Id="QkFX5q3aZ45Ox8P74pUH2o" ManuallySortedPins="true">
-                                          <Patch Id="KnDstdIDqGoN7Jfju24X5U" Name="Create" ManuallySortedPins="true" />
-                                          <Patch Id="FdB0XuCZEUHPkshMnaLGDq" Name="Update" ManuallySortedPins="true" />
-                                          <Patch Id="RDWcD57FUwtMIt2DmJRbJf" Name="Dispose" ManuallySortedPins="true" />
-                                          <Node Bounds="775,758,66,26" Id="PAT7u5jQBC8OiwxPoUAoHP">
+                                        <Pin Id="AsDyZHZkBahPDifAyiRR65" Name="Break" Kind="OutputPin" />
+                                        <ControlPoint Id="UAzgYpF97phN0GGfES9NaC" Bounds="777,674" Alignment="Top" />
+                                        <Patch Id="VcY9n9Df1v6LgNYPj7dA2v" ManuallySortedPins="true">
+                                          <Patch Id="T9Wr4BPyR22LytHVGn4DOz" Name="Create" ManuallySortedPins="true" />
+                                          <Patch Id="FLNDQdpiJHUOoI3pALn3vF" Name="Update" ManuallySortedPins="true" />
+                                          <Patch Id="KVUBB79ui1vO8BYG8xCfvp" Name="Dispose" ManuallySortedPins="true" />
+                                          <Node Bounds="775,769,66,26" Id="KTj8RB0du6LLwQjJv5yENi">
                                             <p:NodeReference LastCategoryFullName="Stride.SampleTextureArraySimple.IInputSetter" LastSymbolSource="VL.Stride.TextureArray.Help.vl">
                                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                               <CategoryReference Kind="InterfaceTypeFlag" Name="IInputSetter" />
                                               <Choice Kind="OperationCallFlag" Name="SetAcessor" />
                                             </p:NodeReference>
-                                            <Pin Id="BbELfkUFLugOibotZNm30J" Name="Input" Kind="StateInputPin" />
-                                            <Pin Id="AqOBI8Jv6iMPlTStpQSHSl" Name="Parameters" Kind="InputPin" />
-                                            <Pin Id="DgpTxDahmboNcaA0w76v8J" Name="Class Name" Kind="InputPin" />
-                                            <Pin Id="ReS8tcqnVLcQXC5S2e8FHl" Name="Output" Kind="StateOutputPin" />
-                                            <Pin Id="UyOIcJznbdENN1YQEOcPvs" Name="Apply" Kind="InputPin" />
+                                            <Pin Id="ROkgljejv1UOs1GekIMrKJ" Name="Input" Kind="StateInputPin" />
+                                            <Pin Id="QcuRZ8h2VJoLbSAGIXDd6G" Name="Parameter Collections" Kind="InputPin" />
+                                            <Pin Id="QUSlXUmYaOhQX20gaXhJDy" Name="Class Name" Kind="InputPin" />
+                                            <Pin Id="KHspo0kIuSuMkoh5nt0tbz" Name="Output" Kind="StateOutputPin" />
+                                            <Pin Id="JXYqauUUUbPMkSO72JF0ae" Name="Apply" Kind="InputPin" />
                                           </Node>
-                                          <Node Bounds="836,724,65,19" Id="EKEYOsektofLfQ5PuwaV6K">
+                                          <Node Bounds="836,735,65,19" Id="AotWBgkiOGvM6RvAUr5PKH">
                                             <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl">
                                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                               <Choice Kind="OperationCallFlag" Name="IsAssigned" />
                                             </p:NodeReference>
-                                            <Pin Id="V1XLv15XwphLpWYkxCS8xE" Name="X" Kind="InputPin" />
-                                            <Pin Id="NqNs8ESQ8RVPIxqbkQ8JUy" Name="Result" Kind="OutputPin" />
-                                            <Pin Id="UGO22n5Fq8SNNMwrsH48jZ" Name="Not Assigned" Kind="OutputPin" />
+                                            <Pin Id="D347Dl7vtPVQaCdDCi1ZoQ" Name="X" Kind="InputPin" />
+                                            <Pin Id="RuHNdlqof28PKS6LtLBMnK" Name="Result" Kind="OutputPin" />
+                                            <Pin Id="JlIulvlw1JaOtSdJOH98Da" Name="Not Assigned" Kind="OutputPin" />
                                           </Node>
                                         </Patch>
                                       </Node>
                                     </Patch>
                                   </Node>
-                                  <Node Bounds="708,502,65,19" Id="OjnXhpnb1uRPZucirBpT5n">
+                                  <Node Bounds="708,513,65,19" Id="IKo1AexFJB8LuRMlTQi4dU">
                                     <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl">
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <Choice Kind="OperationCallFlag" Name="IsAssigned" />
                                     </p:NodeReference>
-                                    <Pin Id="Rgqig2jLSD1Or9uoSA9oZ2" Name="X" Kind="InputPin" />
-                                    <Pin Id="UUnf43sZNSaPFyE1SQhvt0" Name="Result" Kind="OutputPin" />
-                                    <Pin Id="FcdF01PakC3Lg7JzgRWQFb" Name="Not Assigned" Kind="OutputPin" />
+                                    <Pin Id="BAJnL2H9R1sLIKC1uMhAD1" Name="X" Kind="InputPin" />
+                                    <Pin Id="Jn3yryOy0GwNbzI2drdccS" Name="Result" Kind="OutputPin" />
+                                    <Pin Id="LClel4RbETkNPmLHajkEyW" Name="Not Assigned" Kind="OutputPin" />
                                   </Node>
                                 </Patch>
                               </Node>
-                              <Node Bounds="793,367,88,26" Id="VvbedpLo9b6O8S31O1BAQi">
+                              <Node Bounds="793,378,88,26" Id="QfBia8piMjfOHncjb0pcfc">
                                 <p:NodeReference LastCategoryFullName="Stride.API.Rendering.ParameterCollection" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="OperationCallFlag" Name="LayoutCounter" />
                                 </p:NodeReference>
-                                <Pin Id="CIfVKzdmVLROkpd4tmAtiC" Name="Input" Kind="StateInputPin" />
-                                <Pin Id="JsayMF0bTNPOPLNEQWi8Lf" Name="Output" Kind="StateOutputPin" />
-                                <Pin Id="T0v1yOYFupPPB6hZUspycF" Name="Layout Counter" Kind="OutputPin" />
+                                <Pin Id="LbM2DGx58lULStaVYd5G7E" Name="Input" Kind="StateInputPin" />
+                                <Pin Id="Gwwubc48K66PrvulzNisZc" Name="Output" Kind="StateOutputPin" />
+                                <Pin Id="OF9sxOaIGmWPlq0MHOiBvP" Name="Layout Counter" Kind="OutputPin" />
                               </Node>
                             </Patch>
+                            <ControlPoint Id="OCnQa49u9KGLEHQF0svKtL" Bounds="795,362" Alignment="Top" />
                           </Node>
-                          <ControlPoint Id="Eq3CKDhmr8YPqqnjmyboAM" Bounds="651,206" />
-                          <ControlPoint Id="HIe6FtIFXUVLEgo6kmc8UQ" Bounds="778,317" />
                         </Canvas>
                         <Patch Id="VT7tA6H6AejPa7VTVlYwPp" Name="Create" />
                         <Patch Id="Or2os73I0ClMNYdq3So9U3" Name="Update">
@@ -9342,24 +9338,23 @@
                           <Fragment Id="ItikiTPc4h7No8GoZ5OKL3" Patch="VT7tA6H6AejPa7VTVlYwPp" Enabled="true" />
                           <Fragment Id="RuBf2M6SvECNAfQybF2Eez" Patch="Or2os73I0ClMNYdq3So9U3" Enabled="true" />
                         </ProcessDefinition>
-                        <Link Id="MNkumfFbBNCOXL1j0pzWLf" Ids="S7AO8IPIKzSPbtEoO9XMZ5,SfFBOemzHRJPXwfUGsHL5J" />
-                        <Link Id="AVmIOtJUyHDQNFe9E8a8OP" Ids="RiSEEux85pENA7r4VUm5eI,MPmzhKIkAmyLlJcpjEW1Oe" />
-                        <Link Id="N7tudW8QykKQCRqtSGx0zw" Ids="MY6Wfl3gsIYL3SuJ4Y1Wj3,Rgqig2jLSD1Or9uoSA9oZ2" />
-                        <Link Id="B6i9Z1NwTOpNi87dVe75JF" Ids="UUnf43sZNSaPFyE1SQhvt0,TCZywqsD2AFOzYY7GJeerW" />
-                        <Link Id="CkuYtTtHNjlMkanWAMTfHj" Ids="MY6Wfl3gsIYL3SuJ4Y1Wj3,DkyETjMmz8LLJ5TyPuu3fM" />
-                        <Link Id="VGwSYz0yDk5NZNpvxyvKtd" Ids="AasBbT66zgHQdQ8BbZQLuU,AqOBI8Jv6iMPlTStpQSHSl" />
-                        <Link Id="M2HLRhCDgyCMttnPrGlArS" Ids="RiSEEux85pENA7r4VUm5eI,CIfVKzdmVLROkpd4tmAtiC" />
                         <Link Id="IiPoMQvaG6DPvBXDo7MQxx" Ids="Eq3CKDhmr8YPqqnjmyboAM,Ri8eMQbu8yBQVLhOFX1hVy" />
                         <Link Id="DjBaFyqWeYMMc5pp7NmLsK" Ids="KlqvfHd4sddPr0fIiL8s7J,Eq3CKDhmr8YPqqnjmyboAM" IsHidden="true" />
-                        <Link Id="UwuWGobwQaIPqLSDIiqi9X" Ids="Uo6iic2QVdHPYP5YusNHni,ElDjCfYG85cOMlJoM0t6cp" />
-                        <Link Id="S1bil64SUQuPE056sfsQCS" Ids="HoVpnixLykLOC0Etq7KYmL,BbELfkUFLugOibotZNm30J" />
-                        <Link Id="Lh6eqPWSaq9ODmM0yWWvBR" Ids="HoVpnixLykLOC0Etq7KYmL,V1XLv15XwphLpWYkxCS8xE" />
-                        <Link Id="H8JZrcsyPVAMenEY83bgLi" Ids="NqNs8ESQ8RVPIxqbkQ8JUy,UyOIcJznbdENN1YQEOcPvs" />
-                        <Link Id="IEfAWR8aJcQM6Ex3tHOFpv" Ids="Sgp1j9OIjawMDkb2MJimmB,DgpTxDahmboNcaA0w76v8J" />
-                        <Link Id="ShKbLKLYYlIQbCyNlFfd01" Ids="HIe6FtIFXUVLEgo6kmc8UQ,HoVpnixLykLOC0Etq7KYmL" />
                         <Link Id="JhoUeNOTqWkO342OznPGRz" Ids="NV7Nz6wz0MsPgf0J1v7Q5L,HIe6FtIFXUVLEgo6kmc8UQ" IsHidden="true" />
-                        <Link Id="KQsyhzmFZkXM7dP5U43JM6" Ids="JsayMF0bTNPOPLNEQWi8Lf,AasBbT66zgHQdQ8BbZQLuU" />
-                        <Link Id="DeVmrYAHG8eN1xJEIQ0wTK" Ids="T0v1yOYFupPPB6hZUspycF,D2THoxoo8f1Py66njRYuKc" />
+                        <Link Id="VfMs6LGWTyLOSLE529pxAX" Ids="VEVzAsIq9p2MJFnRN13Iqa,BAJnL2H9R1sLIKC1uMhAD1" />
+                        <Link Id="ETeU0iq5g6jLPKbo8KEdXf" Ids="Jn3yryOy0GwNbzI2drdccS,QZVW6N11GXSOOKkJWoR2mQ" />
+                        <Link Id="TDrNVIIjIlELbfebq7m6T6" Ids="VEVzAsIq9p2MJFnRN13Iqa,GgpCwtoh5z2LWQ2WW7KnWN" />
+                        <Link Id="UaWrrjKKzV6OyNX0DEnZSq" Ids="UAzgYpF97phN0GGfES9NaC,ROkgljejv1UOs1GekIMrKJ" />
+                        <Link Id="TnwlwqktGVJOntdekYxz5I" Ids="UAzgYpF97phN0GGfES9NaC,D347Dl7vtPVQaCdDCi1ZoQ" />
+                        <Link Id="EawWizdontZOxxfygbAyDJ" Ids="RuHNdlqof28PKS6LtLBMnK,JXYqauUUUbPMkSO72JF0ae" />
+                        <Link Id="FdRSfvkRIOwO5kJlTLoFKs" Ids="RJrIZ59buKOLYT19CDvbFt,QUSlXUmYaOhQX20gaXhJDy" />
+                        <Link Id="BDyGILyJUnIOwPF50Juprl" Ids="Gwwubc48K66PrvulzNisZc,DgSzUfagjawM1T6R8YNsXC" />
+                        <Link Id="HSfg0A1FPDlMkGbBEWRwks" Ids="OF9sxOaIGmWPlq0MHOiBvP,EhMbkXOnirILTjbaRTUoY5" />
+                        <Link Id="DLanA0To1nZNaL0p9RcJaR" Ids="DMV7eV3VMYlOKcwX69qWF6,OCnQa49u9KGLEHQF0svKtL" />
+                        <Link Id="JX1Uz0neyoLLSBXoj4jPeJ" Ids="OCnQa49u9KGLEHQF0svKtL,LbM2DGx58lULStaVYd5G7E" />
+                        <Link Id="EjuEMWbFBrVMBWPxiDMwN5" Ids="Uo6iic2QVdHPYP5YusNHni,SQMm00WiVyBQFDqHXZqLuY" />
+                        <Link Id="Fo6HEBir1RrOk7rWERIb2u" Ids="DMV7eV3VMYlOKcwX69qWF6,QcuRZ8h2VJoLbSAGIXDd6G" />
+                        <Link Id="JFFZlK1KCoOM5P7phTzYyv" Ids="HIe6FtIFXUVLEgo6kmc8UQ,UAzgYpF97phN0GGfES9NaC" />
                       </Patch>
                     </Node>
                   </Canvas>
@@ -13534,6 +13529,7 @@
                   <Pin Id="MhspLZUap6KLKnaq6hDrFQ" Name="Device" Kind="InputPin" />
                   <Pin Id="PRV8pmjWiTeOZaJ7v0DdKR" Name="Descriptor" Kind="InputPin" />
                   <Pin Id="M9iZ8OYUIvoM3yjXAcRiRq" Name="Content" Kind="InputPin" />
+                  <Pin Id="MLcKGSaMEwTNQKYshui81A" Name="Subscriptions" Kind="InputPin" />
                   <Pin Id="LZzJLLCWSftOCb4KNpvpPI" Name="Result" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="536,466,79,26" Id="NjhweBGK1UkMlbufwx0auK">
@@ -14977,7 +14973,7 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="K08TNIU8XTsLzsNUwzw82F" Location="VL.Skia" Version="2021.4.0-0055-g3e2beca9a4" />
+  <NugetDependency Id="K08TNIU8XTsLzsNUwzw82F" Location="VL.Skia" Version="2021.4.0-0067-g19ccee761f" />
   <DocumentDependency Id="Msnm4D4Er8bLmlwC1L1XQc" Location="./VL.Stride.Graphics.vl" />
   <DocumentDependency Id="M6gCO22oHy1LhLzIK6RyS2" Location="./VL.Stride.Rendering.vl" IsFriend="true" />
   <PlatformDependency Id="QFvbyrdEV0NLXzcTARn7Xg" Location="./src/bin/Debug/netstandard2.0/VL.Stride.Runtime.dll" />

--- a/packages/VL.Stride.Runtime/src/Rendering/Effects/ComputeEffect/ComputeEffectShader2.cs
+++ b/packages/VL.Stride.Runtime/src/Rendering/Effects/ComputeEffect/ComputeEffectShader2.cs
@@ -1,4 +1,5 @@
-﻿using Stride.Core.Diagnostics;
+﻿using Stride.Core;
+using Stride.Core.Diagnostics;
 using Stride.Core.Mathematics;
 using Stride.Graphics;
 using Stride.Rendering;
@@ -7,6 +8,7 @@ using Stride.Shaders;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reactive.Disposables;
 using VL.Lib.Control;
 
 namespace VL.Stride.Rendering.ComputeEffect
@@ -36,8 +38,11 @@ namespace VL.Stride.Rendering.ComputeEffect
             : base(name)
         {
             Parameters = mixinParams;
+            Subscriptions.DisposeBy(this);
             Initialize(context);
         }
+
+        internal readonly CompositeDisposable Subscriptions = new CompositeDisposable();
 
         /// <summary>
         /// The current effect instance.

--- a/packages/VL.Stride.Runtime/src/Rendering/Effects/TextureFXEffect.cs
+++ b/packages/VL.Stride.Runtime/src/Rendering/Effects/TextureFXEffect.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Reactive.Disposables;
+using Stride.Core;
 using Stride.Rendering;
 using Stride.Rendering.Images;
 
@@ -11,8 +13,11 @@ namespace VL.Stride.Rendering
 
         public TextureFXEffect(string effectName = null, bool delaySetRenderTargets = false)
             : base(effectName, delaySetRenderTargets)
-        { 
+        {
+            Subscriptions.DisposeBy(this);
         }
+
+        internal readonly CompositeDisposable Subscriptions = new CompositeDisposable();
 
         public bool IsOutputAssigned => OutputCount > 0 && GetOutput(0) != null;
 

--- a/packages/VL.Stride.Runtime/src/Rendering/Materials/MaterialNodes.cs
+++ b/packages/VL.Stride.Runtime/src/Rendering/Materials/MaterialNodes.cs
@@ -7,6 +7,7 @@ using Stride.Rendering.Materials.ComputeColors;
 using Stride.Shaders;
 using System;
 using System.Collections.Generic;
+using System.Reactive.Disposables;
 using VL.Core;
 using VL.Lib.Basics.Resources;
 
@@ -147,60 +148,6 @@ namespace VL.Stride.Rendering.Materials
                 .AddCachedInput(nameof(MaterialSpecularMicrofacetModelFeature.NormalDistribution), x => x.NormalDistribution.ToEnum(), (x, v) => x.NormalDistribution = v.ToFunction(), i.NormalDistribution.ToEnum())
                 .AddCachedInput(nameof(MaterialSpecularMicrofacetModelFeature.Environment), x => x.Environment.ToEnum(), (x, v) => x.Environment = v.ToFunction(), i.Environment.ToEnum());
         }
-
-        class LiveComputeFloat : ComputeFloat
-        {
-            public ParameterCollection Parameters { get; private set; }
-
-            public void SetValue(float value)
-            {
-                Value = value;
-                // The value accessors cause very weired behaviour, only updating sometimes. We should figure out why. So use the key for now.
-                if (UsedKey is ValueParameterKey<float> floatKey)
-                    Parameters?.Set(floatKey, value);
-            }
-
-            public override ShaderSource GenerateShaderSource(ShaderGeneratorContext context, MaterialComputeColorKeys baseKeys)
-            {
-                var shaderSource = base.GenerateShaderSource(context, baseKeys);
-                Parameters = context.Parameters;
-                // The value accessors cause very weired behaviour, only updating sometimes. We should figure out why. So use the key for now.
-                //Accessor = context.Parameters.GetAccessor(UsedKey as ValueParameterKey<float>);
-                return shaderSource;
-            }
-        }
-
-        class LiveComputeColor : ComputeColor
-        {
-            private ParameterCollection UsedParameters;
-            private ColorSpace UsedColorSpace;
-
-            public void SetValue(Color4 value)
-            {
-                Value = value; // Already takes care of color space conversion when generating the shader
-                if (UsedParameters != null)
-                {
-                    // But when setting it later while the shader is running (live) we need to do it on our own
-                    value = value.ToColorSpace(UsedColorSpace);
-                    if (PremultiplyAlpha)
-                        value = Color4.PremultiplyAlpha(value);
-
-                    // The value accessors cause very weired behaviour, only updating sometimes. We should figure out why. So use the key for now.
-                    if (UsedKey is ValueParameterKey<Color4> color4Key)
-                        UsedParameters.Set(color4Key, ref value);
-                    else if (UsedKey is ValueParameterKey<Color3> color3Key)
-                        UsedParameters.Set(color3Key, value.ToColor3());
-                }
-            }
-
-            public override ShaderSource GenerateShaderSource(ShaderGeneratorContext context, MaterialComputeColorKeys baseKeys)
-            {
-                var shaderSource = base.GenerateShaderSource(context, baseKeys);
-                UsedColorSpace = context.ColorSpace;
-                UsedParameters = context.Parameters;
-                return shaderSource;
-            }
-        }
     }
 
     /// <summary>
@@ -210,6 +157,7 @@ namespace VL.Stride.Rendering.Materials
     {
         readonly MaterialAttributes @default = new MaterialAttributes();
         readonly IResourceHandle<Game> gameHandle;
+        readonly SerialDisposable subscriptions = new SerialDisposable();
 
         public MaterialBuilder(NodeContext nodeContext)
         {
@@ -218,6 +166,7 @@ namespace VL.Stride.Rendering.Materials
 
         public void Dispose()
         {
+            subscriptions.Dispose();
             gameHandle.Dispose();
         }
 
@@ -271,7 +220,9 @@ namespace VL.Stride.Rendering.Materials
                 Layers = Layers
             };
             var game = gameHandle.Resource;
-            return MaterialExtensions.New(game.GraphicsDevice, descriptor, game.Content);
+            var s = new CompositeDisposable();
+            subscriptions.Disposable = s;
+            return MaterialExtensions.New(game.GraphicsDevice, descriptor, game.Content, s);
         }
     }
 

--- a/packages/VL.Stride.Runtime/src/Shaders/ComputeEffectDispatcher.cs
+++ b/packages/VL.Stride.Runtime/src/Shaders/ComputeEffectDispatcher.cs
@@ -9,6 +9,8 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Buffer = Stride.Graphics.Buffer;
+using System.Reactive.Disposables;
+using Stride.Core;
 
 namespace VL.Stride.Shaders
 {
@@ -21,6 +23,8 @@ namespace VL.Stride.Shaders
         public ComputeEffectDispatcher(RenderContext context, string effectName = "ComputeEffectShader")
             : base(context, null)
         {
+            Subscriptions.DisposeBy(this);
+
             pipelineState = new MutablePipelineState(context.GraphicsDevice);
 
             // Setup the effect compiler
@@ -35,6 +39,8 @@ namespace VL.Stride.Shaders
 
             SetDefaultParameters();
         }
+
+        internal readonly CompositeDisposable Subscriptions = new CompositeDisposable();
 
         /// <summary>
         /// The current effect instance.

--- a/packages/VL.Stride.Runtime/src/Shaders/ParameterUpdater.cs
+++ b/packages/VL.Stride.Runtime/src/Shaders/ParameterUpdater.cs
@@ -1,0 +1,152 @@
+﻿using Stride.Rendering;
+using Stride.Rendering.Materials;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Reactive.Disposables;
+
+namespace VL.Stride.Shaders.ShaderFX
+{
+    /// <summary>
+    /// Helper class to easily track parameter collections and update one of its parameters.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the parameter value</typeparam>
+    /// <typeparam name="TKey">The type of the parameter key</typeparam>
+    abstract class ParameterUpdater<TValue, TKey>
+        where TKey : ParameterKey
+    {
+        private static readonly EqualityComparer<TValue> comparer = EqualityComparer<TValue>.Default;
+
+        // In most of the cases the parameter collection is known from the start and no other will come into play (pin and effect are in the same node)
+        private readonly ParameterCollection parameters;
+
+        // In case we end up in a shader graph multiple parameter collections could pop up (one for every effect) we need to keep track of
+        private Dictionary<(ParameterCollection, TKey), RefCountDisposable> trackedCollections;
+
+        private TValue value;
+        private TKey key;
+
+        public ParameterUpdater(ParameterCollection parameters = default, TKey key = default)
+        {
+            this.parameters = parameters;
+            this.key = key;
+        }
+
+        public TValue Value
+        {
+            get => value;
+            set
+            {
+                if (!comparer.Equals(value, Value))
+                {
+                    this.value = value;
+
+                    if (parameters != null)
+                    {
+                        Upload(parameters, key, ref value);
+                    }
+
+                    if (trackedCollections != null)
+                    {
+                        foreach (var (parameters, key) in trackedCollections.Keys)
+                            Upload(parameters, key, ref value);
+                    }
+                }
+            }
+        }
+
+        public ImmutableArray<ParameterCollection> GetTrackedCollections()
+        {
+            if (trackedCollections is null)
+                return ImmutableArray<ParameterCollection>.Empty;
+
+            var result = ImmutableArray.CreateBuilder<ParameterCollection>(trackedCollections.Count);
+            foreach (var (parameters, _) in trackedCollections.Keys)
+                result.Add(parameters);
+            return result.ToImmutable();
+        }
+
+        public void Track(ShaderGeneratorContext context)
+        {
+            Track(context, key);
+        }
+
+        public void Track(ShaderGeneratorContext context, TKey key)
+        {
+            if (context.TryGetSubscriptions(out var s))
+                s.Add(Subscribe(context.Parameters, key));
+        }
+
+        public IDisposable Subscribe(ParameterCollection parameters, TKey key)
+        {
+            var x = (parameters, key);
+
+            var trackedCollections = this.trackedCollections ??= new Dictionary<(ParameterCollection, TKey), RefCountDisposable>();
+            if (trackedCollections.TryGetValue(x, out var disposable))
+                return disposable.GetDisposable();
+
+            disposable = new RefCountDisposable(Disposable.Create(() => trackedCollections.Remove(x)));
+            trackedCollections.Add(x, disposable);
+            Upload(parameters, key, ref value);
+            return disposable;
+        }
+
+        protected abstract void Upload(ParameterCollection parameters, TKey key, ref TValue value);
+    }
+
+    sealed class ValueParameterUpdater<T> : ParameterUpdater<T, ValueParameterKey<T>>
+        where T : struct
+    {
+        public ValueParameterUpdater(ParameterCollection parameters = null, ValueParameterKey<T> key = null) : base(parameters, key)
+        {
+
+        }
+
+        protected override void Upload(ParameterCollection parameters, ValueParameterKey<T> key, ref T value)
+        {
+            parameters.Set(key, ref value);
+        }
+    }
+
+    sealed class ArrayParameterUpdater<T> : ParameterUpdater<T[], ValueParameterKey<T>>
+        where T : struct
+    {
+        public ArrayParameterUpdater(ParameterCollection parameters = null, ValueParameterKey<T> key = null) : base(parameters, key)
+        {
+
+        }
+
+        protected override void Upload(ParameterCollection parameters, ValueParameterKey<T> key, ref T[] value)
+        {
+            if (value.Length > 0)
+                parameters.Set(key, value);
+        }
+    }
+
+    sealed class ObjectParameterUpdater<T> : ParameterUpdater<T, ObjectParameterKey<T>>
+        where T : class
+    {
+        public ObjectParameterUpdater(ParameterCollection parameters = null, ObjectParameterKey<T> key = null) : base(parameters, key)
+        {
+
+        }
+
+        protected override void Upload(ParameterCollection parameters, ObjectParameterKey<T> key, ref T value)
+        {
+            parameters.Set(key, value);
+        }
+    }
+
+    sealed class PermutationParameterUpdater<T> : ParameterUpdater<T, PermutationParameterKey<T>>
+    {
+        public PermutationParameterUpdater(ParameterCollection parameters = null, PermutationParameterKey<T> key = null) : base(parameters, key)
+        {
+
+        }
+
+        protected override void Upload(ParameterCollection parameters, PermutationParameterKey<T> key, ref T value)
+        {
+            parameters.Set(key, value);
+        }
+    }
+}

--- a/packages/VL.Stride.Runtime/src/Shaders/ShaderFX/Input/InputValue.cs
+++ b/packages/VL.Stride.Runtime/src/Shaders/ShaderFX/Input/InputValue.cs
@@ -1,61 +1,43 @@
 using Stride.Rendering;
 using Stride.Rendering.Materials;
 using Stride.Shaders;
-using Buffer = Stride.Graphics.Buffer;
 using static VL.Stride.Shaders.ShaderFX.ShaderFXUtils;
-
 
 namespace VL.Stride.Shaders.ShaderFX
 {
-    public class InputValue<T> : ComputeValue<T> where T : struct
+    public class InputValue<T> : ComputeValue<T>
+        where T : struct
     {
+        private readonly ValueParameterUpdater<T> updater = new ValueParameterUpdater<T>();
+
         public InputValue(ValueParameterKey<T> key = null, string constantBufferName = null)
         {
             Key = key;
             ConstantBufferName = constantBufferName;
         }
 
-        private T inputValue;
-
         /// <summary>
         /// Can be updated from mainloop
         /// </summary>
         public T Input
         { 
-            get => inputValue;
-
-            set
-            {
-                if (!inputValue.Equals(value) || compiled)
-                {
-                    this.inputValue = value;
-
-                    if (Parameters != null && UsedKey != null)
-                        Parameters.Set(UsedKey, inputValue);
-
-                    compiled = false;
-                }
-            }
+            get => updater.Value;
+            set => updater.Value = value;
         }
 
-        public ValueParameterKey<T> UsedKey { get; protected set; }
         public ValueParameterKey<T> Key { get; }
         public string ConstantBufferName { get; private set; }
 
-        ParameterCollection Parameters;
-        bool compiled;
         public override ShaderSource GenerateShaderSource(ShaderGeneratorContext context, MaterialComputeColorKeys baseKeys)
         {
-
             ShaderClassSource shaderClassSource;
 
             if (Key == null)
             {
-                UsedKey = GetInputKey(context);
-                context.Parameters.Set(UsedKey, Input);
+                var usedKey = GetInputKey(context);
 
-                // remember parameters for updates from main loop 
-                Parameters = context.Parameters;
+                // keep track of the parameters
+                updater.Track(context, usedKey);
 
                 // find constant buffer name
                 var constantBufferName = ConstantBufferName;
@@ -65,15 +47,13 @@ namespace VL.Stride.Shaders.ShaderFX
                     constantBufferName = context is MaterialGeneratorContext ? "PerMaterial" : "PerUpdate";
                 }
 
-                shaderClassSource = GetShaderSourceForType<T>("Input", UsedKey, constantBufferName);
+                shaderClassSource = GetShaderSourceForType<T>("Input", usedKey, constantBufferName);
             }
             else
             {
-                UsedKey = Key;
-                shaderClassSource = GetShaderSourceForType<T>("InputKey", UsedKey);
+                shaderClassSource = GetShaderSourceForType<T>("InputKey", Key);
             }
 
-            compiled = true;
 
             return shaderClassSource;
         }


### PR DESCRIPTION
# Summary
The PR lifts the restriction that nodes feeding values or resources into the shader graph could only be connected to one sink.

# Details
My initial approach where the sources kept a weak reference on the parameter collections of the sink didn't work because on disconnect the sink was still alive and therefor the source would still write into it.

The approach now is to provide a subscription object (a `CompositeDisposable`) while generating the shader graph (through the `ShaderGeneratorContext.Tags` property) where leaves can tie their value subscription to the lifetime of the entire shader graph.

# Example
The two links from the ColorMap node work as expected:
![image](https://user-images.githubusercontent.com/573618/115959682-b41eb000-a50d-11eb-9401-be92712dd3b0.png)

# Related issues
#323 