### PR TITLE
Replaces the plain `ProfilingKey` type forward with a process node

### DIFF
--- a/packages/VL.Stride.Runtime/VL.Stride.Rendering.vl
+++ b/packages/VL.Stride.Runtime/VL.Stride.Rendering.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="PwY6LKPeo6iO0yovVrdC7t" LanguageVersion="2021.4.0.183" Version="0.128">
-  <NugetDependency Id="RpPAo2Mz2hINnzdyPwCgpq" Location="VL.CoreLib" Version="2021.4.0-0171-gf5b4947bff" />
+<Document xmlns:p="property" Id="PwY6LKPeo6iO0yovVrdC7t" LanguageVersion="2021.4.0.194" Version="0.128">
+  <NugetDependency Id="RpPAo2Mz2hINnzdyPwCgpq" Location="VL.CoreLib" Version="2021.4.0-0192-g8d2005b8ce" />
   <Patch Id="J2Vq6inJsyVOtMcCMNylcQ">
     <Canvas Id="JSu0taSJ8rOOa9Gx7GIL6b" DefaultCategory="Stride" CanvasType="FullCategory">
       <Canvas Id="KouU4NDrV4yMANodMZ0uIi" Name="Utils" Position="179,482">
@@ -301,7 +301,7 @@
               <Link Id="T6O6CmGa36LNHUZGqrWe3e" Ids="DAmfQzCFFt7N2fd70y8rMR,HI4bt2Ph2SrLp8TF7PthUb" />
               <Link Id="SAghJko2VcbMJzq2uGVB5j" Ids="Sp9UevBsIDlPOIXFrJk2a2,O7WtHCt3QcuMj9kf1Og9k6" />
               <Node Bounds="542,211,36,26" Id="AQ4NSLJc7x1QOmcRrwm1i0">
-                <p:NodeReference LastCategoryFullName="Stride.API.Core.Mathematics.Int2" LastSymbolSource="VL.Stride.Core.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Int2" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="Int2" />
                   <Choice Kind="OperationCallFlag" Name="Split" />
@@ -380,14 +380,14 @@
               </Node>
               <Link Id="TVxvPocd3R9QH5MWj6hPcA" Ids="EqpnUYbiLxjP0KEqpB07Ah,VEHzwPn8vaRPzzzECwGeTq" />
               <Link Id="S79ZIQhoIP9OkoFGGLh46e" Ids="M6FvqxY4wgqOgSAgKidRfs,UmlDD1vkzUsMdY2K6LySaq" />
-              <Pin Id="QAVw06XIH60NAW9kpVDfiT" Name="Result" Kind="OutputPin" Bounds="1194,716" />
               <Pin Id="A5av7Wl2EQ9NieibfBLOgU" Name="Point Coint" Kind="InputPin" Bounds="297,217" DefaultValue="5, 5">
-                <p:TypeAnnotation LastCategoryFullName="Stride.API.Core.Mathematics" LastSymbolSource="VL.Stride.Core.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Int2" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="CYbtHllXxV9LnrJuS7WOMK" Name="Builder To Fill" Kind="InputPin" Bounds="910,270" />
               <Pin Id="UEou00OVGGKL8PLKwtH3rJ" Name="Clear Builder" Kind="InputPin" Bounds="1026,246" />
+              <Pin Id="QAVw06XIH60NAW9kpVDfiT" Name="Result" Kind="OutputPin" Bounds="1194,716" />
             </Patch>
           </Node>
         </Canvas>
@@ -889,7 +889,6 @@
                     <Pin Id="D03aULlSmBWOjAQ44Oorz8" Name="Depth Stencil State" Kind="InputPin" />
                     <Pin Id="VaUeQMGs9PzMtW9Enl3CcV" Name="Mesh" Kind="InputPin" />
                     <Pin Id="Ub7qkA6cwsiLkjUFFumuKG" Name="Instance Count" Kind="InputPin" />
-                    <Pin Id="TK28xouOz07LijYzOtJn6U" Name="Profiling Name" Kind="InputPin" />
                     <Pin Id="AbfgOUdxpJnQJqhffLSCTn" Name="Topology" Kind="InputPin" />
                     <Pin Id="JiEhqRl5YSfOkrVGaIXtq5" Name="Draw Count" Kind="InputPin" />
                     <Pin Id="MA8aZ8VtUR2OZSfxxVcFsI" Name="Output" Kind="StateOutputPin" />
@@ -977,7 +976,6 @@
                 <ProcessDefinition Id="FZ2k0mUaI70Ovy7YjquDlM">
                   <Fragment Id="FbCsPXEWCsqMYB8OPQmzvx" Patch="FGSAkswwya7PGd4TJqaY1V" Enabled="true" />
                   <Fragment Id="HG1Czgb8NnNPtdMEM3h2oB" Patch="VUThNRX4Tn3NeQ4SuaS4bT" Enabled="true" />
-                  <Fragment Id="Hs5Mc9g4kQ6LQBqRdQxjWC" Patch="VzAH2I3yynpOcJb6HVf6Aw" />
                 </ProcessDefinition>
                 <Link Id="LyxoEeSjFUULm9IiQpKmB5" Ids="Vphe3Pnnlr0Pp4kPDwCUyI,EWyfFxI8lvONZsljoKJoBB" IsHidden="true" />
                 <Link Id="VNxFxiOp1JnLsZzyLuuRBu" Ids="MA8aZ8VtUR2OZSfxxVcFsI,RDfbSgYMEMsMG3jlUZoPo3" />
@@ -1012,7 +1010,6 @@
                   <Pin Id="RoRF6qFm0roNXvbUndqIRy" Name="Ray" Kind="InputPin" Bounds="897,424" />
                   <Pin Id="LtH1mQvemG3MC5W2ihH7uv" Name="Output" Kind="OutputPin" Bounds="720,866" />
                 </Patch>
-                <Patch Id="VzAH2I3yynpOcJb6HVf6Aw" Name="CreateDefault (Hidden)" />
               </Patch>
             </Node>
             <!--
@@ -1037,7 +1034,6 @@
                     <Pin Id="Tdf18ctsYe1P7m344cMS89" Name="Depth Stencil State" Kind="InputPin" />
                     <Pin Id="T3Xd5UhEoGANwQlNZKQAT6" Name="Mesh" Kind="InputPin" />
                     <Pin Id="TIOCsPWwFAxOBucOla0cy7" Name="Instance Count" Kind="InputPin" />
-                    <Pin Id="TylkpJuUZrhOdAaK6gpbFF" Name="Profiling Name" Kind="InputPin" />
                     <Pin Id="K1kBdE4RIIGOnI8oaHXuaA" Name="Topology" Kind="InputPin" />
                     <Pin Id="HOIbMiD8d68OWY3tfpJrj4" Name="Draw Count" Kind="InputPin" />
                     <Pin Id="Jk3pcwPEGklPeBHrM468vZ" Name="Output" Kind="StateOutputPin" />
@@ -1106,7 +1102,6 @@
                 <ProcessDefinition Id="EadH7nn4akcNfScYTRZNqz">
                   <Fragment Id="R4rnlDExs78QCQ9V0LUdFH" Patch="SrYgJ1i7GFONiw1zK5RPjX" Enabled="true" />
                   <Fragment Id="O4xZAPHFrPWNyYRsM3PnZN" Patch="BXpgAhYMggBLK1OanRI5u8" Enabled="true" />
-                  <Fragment Id="J3F8sEydP7COvhU9qHSAqf" Patch="IY1hJyASWMSOvU9SJmcw7Y" />
                 </ProcessDefinition>
                 <Link Id="U3YYzYEm7nVNudh8tnvEur" Ids="Jk3pcwPEGklPeBHrM468vZ,S8rWehY0ki6QOmMJZDRmop" />
                 <Link Id="SCZx6p3t9mwPINC9ZL91CW" Ids="S8rWehY0ki6QOmMJZDRmop,KsZlBcmT7V4QL94Fi5TOeG" IsHidden="true" />
@@ -1135,7 +1130,6 @@
                   <Pin Id="Lk3vEzxhGlRQbtleDdqvWC" Name="Depth Stencil State" Kind="InputPin" Bounds="396,489" />
                   <Pin Id="KsZlBcmT7V4QL94Fi5TOeG" Name="Output" Kind="OutputPin" Bounds="720,866" />
                 </Patch>
-                <Patch Id="IY1hJyASWMSOvU9SJmcw7Y" Name="CreateDefault (Hidden)" />
               </Patch>
             </Node>
             <!--
@@ -1160,7 +1154,6 @@
                     <Pin Id="IkGBli3bPUULkq77bgrUrV" Name="Depth Stencil State" Kind="InputPin" />
                     <Pin Id="IF3ZoKvpsC6Mvl5TIDloHN" Name="Mesh" Kind="InputPin" />
                     <Pin Id="LBnkClRrSvFLzhtTpLQsf9" Name="Instance Count" Kind="InputPin" />
-                    <Pin Id="Sh4bMeVnNVhLdshGELrkao" Name="Profiling Name" Kind="InputPin" />
                     <Pin Id="AZWpVAAej9tPLm0jkCNzEc" Name="Topology" Kind="InputPin" />
                     <Pin Id="FHuDKnveTcZO3yoYqzrtpy" Name="Draw Count" Kind="InputPin" />
                     <Pin Id="OPtMo36vSLULrKZM44c9Ta" Name="Output" Kind="StateOutputPin" />
@@ -1243,7 +1236,6 @@
                 <ProcessDefinition Id="GMocGXGfaYELK1mPXKihYq">
                   <Fragment Id="K2Etf3UvQDlM0swDxGe0Pn" Patch="GPOWlhwPTuoQVt8okebaEI" Enabled="true" />
                   <Fragment Id="H20rwF552sbORtbTvsmgls" Patch="TyI2A8KM5XLNv6iZz4JGQ1" Enabled="true" />
-                  <Fragment Id="LtJYx3FRBEmLZfTIbZQPsm" Patch="QbgeAOdy9YKNtDpb1WDEBa" />
                 </ProcessDefinition>
                 <Link Id="LszBOaROVvsNNYeRD6nAdb" Ids="N4I4ilydknxMAVzgAMEkFl,R9kmAjMtv0CNtquUPCiXDI" IsHidden="true" />
                 <Link Id="OBxiPz1xdXYPrCjOle54KA" Ids="OPtMo36vSLULrKZM44c9Ta,Daz9xZVOK4IN3xZAtTEorA" />
@@ -1259,7 +1251,6 @@
                 <Link Id="OKNWSm8Ora5M9ZxOzUu0ct" Ids="MrP0z5qeHxAL39zqOSyrDW,RFCc6ZlI5YpNIQ2D8e4QKf" />
                 <Link Id="Qnf4OKOvBrsNGLLlZEXwyT" Ids="OyS3drRZkIjNo8bvqnI4Ql,GIKqqLXVShcLUqfPgTG0tl" />
                 <Link Id="AzJT0uaYch3Lk0WGjxaLiP" Ids="THI9WIO5OcoMzB9c7GkuhB,HQ34bKAoozONl49G6JIAJk" />
-                <Patch Id="QbgeAOdy9YKNtDpb1WDEBa" Name="CreateDefault (Hidden)" />
               </Patch>
             </Node>
             <!--
@@ -1284,7 +1275,6 @@
                     <Pin Id="NQ9c1MdGKgEMPoHBuqGMCr" Name="Depth Stencil State" Kind="InputPin" />
                     <Pin Id="NWJs97NJbSeLqPWmVfF1Dn" Name="Mesh" Kind="InputPin" />
                     <Pin Id="BlE5YCNuHrlOgAEa6u9nRx" Name="Instance Count" Kind="InputPin" />
-                    <Pin Id="OO51ldZGFfuMmiUeqiXOrJ" Name="Profiling Name" Kind="InputPin" />
                     <Pin Id="SYLfcY2geYYLbXYyPTncNJ" Name="Topology" Kind="InputPin" />
                     <Pin Id="Pq0ZhdQRYBOPXfURoDda88" Name="Draw Count" Kind="InputPin" />
                     <Pin Id="GlidDE44aN2MvXiC008z5Y" Name="Output" Kind="StateOutputPin" />
@@ -1380,7 +1370,6 @@
                 <ProcessDefinition Id="Ip4RnCmlaPEOalKwKJ46KO">
                   <Fragment Id="PtqfYgr8peUOLDIxA2tdpk" Patch="UaFIAr6GrSuQAgHuidPUut" Enabled="true" />
                   <Fragment Id="KlWFwNp8502N65JGutSVCC" Patch="NckZwdhETJBPUmxVDk1VZT" Enabled="true" />
-                  <Fragment Id="JnSagaoYEsUP4xuIWx48GH" Patch="FIT2Q7XB1KEN9QoHR9UigN" />
                 </ProcessDefinition>
                 <Link Id="VGepmxx5wzIMEsEAuiuTV2" Ids="AAWolw39IzIL4ZNJ1lM4Kd,CPLLoysVY4DN8oMA9iUdmM" IsHidden="true" />
                 <Link Id="BOiHFANLK5hNPCuWMg5FVz" Ids="GlidDE44aN2MvXiC008z5Y,VVLvxsFtm33O7G5jsJgu7X" />
@@ -1397,7 +1386,6 @@
                 <Link Id="QuScTqlcX1nMBUeY50nKkI" Ids="MihwIVpUw6wL7vdneHy936,Bir4tuvzdxiN1XjsAx7usd" />
                 <Link Id="JDGuWsFuRM8QQYsnq6mgdw" Ids="Lq92lOba9xTOv8kfGcYb85,ErJtc3UcUcpK9mmb3Opa8I" />
                 <Link Id="US11GS0fA65MEy74Fn21qB" Ids="JLcigeBUv1MN0AlnrAplcy,Nzf6euKW7TMN6D0XobmI10" />
-                <Patch Id="FIT2Q7XB1KEN9QoHR9UigN" Name="CreateDefault (Hidden)" />
               </Patch>
             </Node>
             <!--
@@ -1422,7 +1410,6 @@
                     <Pin Id="Sxcs0QOCpT2PHoEar3wt6F" Name="Depth Stencil State" Kind="InputPin" />
                     <Pin Id="CZ6myBrXA1TNg9mDO7JO5N" Name="Mesh" Kind="InputPin" />
                     <Pin Id="ERws1R3cIWeNRCQGxx1RXP" Name="Instance Count" Kind="InputPin" />
-                    <Pin Id="ViYWKNwW2Z0MqB8kdQx3Xl" Name="Profiling Name" Kind="InputPin" />
                     <Pin Id="AL709XAwYhFLD9rF7oBrQe" Name="Topology" Kind="InputPin" />
                     <Pin Id="KhwGS7sp4kYMhk6MFTJjzG" Name="Draw Count" Kind="InputPin" />
                     <Pin Id="IBHSyk7GY3ZN6RlNfyVNmX" Name="Output" Kind="StateOutputPin" />
@@ -1598,7 +1585,6 @@
                 <ProcessDefinition Id="RTd5gHBCSeZLiNJB3aaIQm">
                   <Fragment Id="JDcBO1hNgf3NqYslWRuj6r" Patch="Ke3oCegLlulMSL5DVQZjx3" Enabled="true" />
                   <Fragment Id="S0YFiQQMUqyMbfb7lykmpK" Patch="UvfR0qcVcKZMAkiDwfeNbv" Enabled="true" />
-                  <Fragment Id="V5u0FNvlbSdK97zfaXJWei" Patch="DGLGAtIQLHLPViG4ym4CXu" />
                 </ProcessDefinition>
                 <Link Id="NmEvxQJeJsiLrDpQsHhIC6" Ids="QpABxQy503ROkoWxDk6yXm,NF9pn6xt1TsPZ9Kql6yMkw" IsHidden="true" />
                 <Link Id="EHWNIfel46KOLgHsdXnep3" Ids="IBHSyk7GY3ZN6RlNfyVNmX,HMsZFgceHO6L0QuaUIaGzG" />
@@ -1633,7 +1619,6 @@
                 <Link Id="FoffshIjVRMMjmesEPl0La" Ids="FzTXNxhjU7UPW41HFvaeH8,DnaGZnujt3VO1vKXYFy1HS" />
                 <Link Id="T22X4GNWEibMWIkaLUn693" Ids="TTM4QbF8kwFNixH3UuzHnL,S0aDsNbwn0KNmZgXTBkExu" />
                 <Link Id="NHyOxPlr0pzPyXbsynbZLF" Ids="EZySdayP6oNQKPAjSdEV9B,OmWacnEpwq8MN4MFKCukZV" />
-                <Patch Id="DGLGAtIQLHLPViG4ym4CXu" Name="CreateDefault (Hidden)" />
               </Patch>
             </Node>
             <!--
@@ -1658,7 +1643,6 @@
                     <Pin Id="ILiNcLCn4aUNK1LLbPXPas" Name="Depth Stencil State" Kind="InputPin" />
                     <Pin Id="CUpmAjPyl4iLOOzW7WVA6y" Name="Mesh" Kind="InputPin" />
                     <Pin Id="A1UvpYQ2wzlNT1sGGR6lAu" Name="Instance Count" Kind="InputPin" />
-                    <Pin Id="NRyV1HX7aN7LmQJrFah7hl" Name="Profiling Name" Kind="InputPin" />
                     <Pin Id="DBYmoMcbOGtLTKRm7ybuuE" Name="Topology" Kind="InputPin" />
                     <Pin Id="C7tDmZGFwzOPyKTKK21T51" Name="Draw Count" Kind="InputPin" />
                     <Pin Id="KirqtkLGFD4Pt7lElvgpwN" Name="Output" Kind="StateOutputPin" />
@@ -1766,7 +1750,6 @@
                 <ProcessDefinition Id="HBrgJKg3V4fMSJplrbngZ7">
                   <Fragment Id="ItcCm97GKXuNCPCsx8k12h" Patch="KW89LOfeUvOOYn6eoLUq8e" Enabled="true" />
                   <Fragment Id="AL0Vclz3DH3OV6ntxuViA0" Patch="Ux1cDVXtAyEOcDcXNyAYyg" Enabled="true" />
-                  <Fragment Id="JSXgeW79Ra0OUXy4vs8M3z" Patch="F6NpGQ7Q1ygQWyCe0tgaNk" />
                 </ProcessDefinition>
                 <Link Id="FLgVd6SBr57QXgD4YUGpd5" Ids="KirqtkLGFD4Pt7lElvgpwN,R9KMsL5yW3FPkm0Mqa4ueB" />
                 <Link Id="MEYjnbJrO1hLwLXzFRnR4j" Ids="R9KMsL5yW3FPkm0Mqa4ueB,K22bHZy9LoTMjCWsoP0pNw" IsHidden="true" />
@@ -1789,7 +1772,6 @@
                 <Link Id="UhOXdt63lbdOriA19B7tyP" Ids="ElGhocjqk07PDWS5bCLPxu,Rp8D2umHsVaPUNoX0h08s7" />
                 <Link Id="JUxFwemHJdxOqX1XAp0xxF" Ids="TaQQca6Rj9iMPNaZsjPMZk,VqPm1JUgAMFNy88DQJVmNT" />
                 <Link Id="Qf18CJf6v1xPI2UyQUgZ53" Ids="E4oR7a7HzthMLx9cMcxaE6,AUT3hQu1uXJOlKoHMzXBH2" />
-                <Patch Id="F6NpGQ7Q1ygQWyCe0tgaNk" Name="CreateDefault (Hidden)" />
               </Patch>
             </Node>
             <!--
@@ -1814,7 +1796,6 @@
                     <Pin Id="VqVHARvuhchQFkoArpWBBd" Name="Depth Stencil State" Kind="InputPin" />
                     <Pin Id="FMHRhnAevv3M1SNCUDicB5" Name="Mesh" Kind="InputPin" />
                     <Pin Id="VqC90HTdp4kNF2NsLM86bo" Name="Instance Count" Kind="InputPin" />
-                    <Pin Id="RXD9ssST0ckNQKPsz3nfp6" Name="Profiling Name" Kind="InputPin" />
                     <Pin Id="PrBIzUwPM69NHDKtLw0a4Q" Name="Update" Kind="InputPin" />
                     <Pin Id="U8jCC1thfp5N07jZ9sAef7" Name="Topology" Kind="InputPin" />
                     <Pin Id="LnZc6n4SzUbQa43e2wfknZ" Name="Draw Count" Kind="InputPin" />
@@ -1895,7 +1876,6 @@
                 <ProcessDefinition Id="RIbk5Qlx6mdM2ML5XFiH6B">
                   <Fragment Id="AFmcdqfD3rtNc9d6PbBOFp" Patch="U49cEhITrP1PtpBmNa29Iz" Enabled="true" />
                   <Fragment Id="R1zSUgKSIZDMWqjs4XG27i" Patch="Orfn1wOqrVuP3Jf7ZC6g6s" Enabled="true" />
-                  <Fragment Id="JKAAo7zRPLWLgH5LVgRoH5" Patch="VMBTlI9a0weO6vLeeRwZry" />
                 </ProcessDefinition>
                 <Link Id="QbixAsFck7CPFJhuwG5x7i" Ids="PFVPetdXVrZL2Dh1RJ36OU,AcfuPMv4dedNCTm9MwOfUd" />
                 <Link Id="TPIVBrovyIsMFaD37sdyqg" Ids="AcfuPMv4dedNCTm9MwOfUd,JdJKvWKjwMQPN3Cj3awmqX" IsHidden="true" />
@@ -1921,7 +1901,6 @@
                   <Pin Id="TIFmqQyaFq6MsHMdAVdesd" Name="Rectangle" Kind="InputPin" Bounds="897,424" />
                   <Pin Id="JdJKvWKjwMQPN3Cj3awmqX" Name="Output" Kind="OutputPin" Bounds="720,866" />
                 </Patch>
-                <Patch Id="VMBTlI9a0weO6vLeeRwZry" Name="CreateDefault (Hidden)" />
               </Patch>
             </Node>
             <!--
@@ -1947,17 +1926,11 @@
                     <Pin Id="ROidTB2XxPaNLrHZIo2Ibu" Name="Depth Stencil State" Kind="InputPin" />
                     <Pin Id="HnlmwFfkUkULVNZsCbhtQO" Name="Mesh" Kind="InputPin" />
                     <Pin Id="O8Vo2McTyWDLYqwCrpTEQR" Name="Instance Count" Kind="InputPin" />
-                    <Pin Id="KQcagpujauQQd42cEL9YXE" Name="Profiling Name" Kind="InputPin" />
                     <Pin Id="GfesottYJsGOjvpmIl64iT" Name="Update" Kind="InputPin" />
                     <Pin Id="MQCMivARZLkOuK25qs97GH" Name="Topology" Kind="InputPin" />
                     <Pin Id="NaWMxPxmxd2ME9F02NTYHV" Name="Draw Count" Kind="InputPin" />
                     <Pin Id="EUoMGNQcKZTODFHpJX7b5x" Name="Output" Kind="StateOutputPin" />
                   </Node>
-                  <Pad Id="Sgt2COYof5EN8wkXU77eik" Comment="Profiling Name" Bounds="506,632,132,15" ShowValueBox="true" isIOBox="true" Value="ColorQuadMeshDrawer">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                      <Choice Kind="TypeFlag" Name="String" />
-                    </p:TypeAnnotation>
-                  </Pad>
                   <ControlPoint Id="H4M9R7tzOvbNloUf9E9Lcn" Bounds="195,374" />
                   <ControlPoint Id="PBBzWSIZEkMLSCFQl0gSQY" Bounds="249,374" />
                   <ControlPoint Id="RCgpuiAQFtUNaI1ScKcf1i" Bounds="549,166" />
@@ -2067,7 +2040,6 @@
                   <Fragment Id="P3eyV6P0NX5MiQotYypekj" Patch="GIBw0LH1rdqN7JklUhrXRe" Enabled="true" />
                   <Fragment Id="B5wjSQH12GzPOGlDuUXdVi" Patch="QvfPJU3dh98MmQDiMTwImS" Enabled="true" />
                 </ProcessDefinition>
-                <Link Id="DA2VyIwZtFhMF8gfSY8kRf" Ids="Sgt2COYof5EN8wkXU77eik,KQcagpujauQQd42cEL9YXE" />
                 <Link Id="ER041DZi0ppOBkcPAxEgVZ" Ids="TwICRwtcxqiL24NF3rXEmq,H4M9R7tzOvbNloUf9E9Lcn" IsHidden="true" />
                 <Link Id="RagXHl8mBASMKvbjZJgg50" Ids="Rb8jbmbMddCLYU5Y4XP7pL,PBBzWSIZEkMLSCFQl0gSQY" IsHidden="true" />
                 <Link Id="U2Yw7P5JHc7PYifBQRw9CK" Ids="Rb8jbmbMddCLYU5Y4XP7pL,RCgpuiAQFtUNaI1ScKcf1i" IsHidden="true" />
@@ -5252,7 +5224,6 @@
                     <Pin Id="A0b7JO3On0RPblgpfay7iX" Name="Depth Stencil State" Kind="InputPin" />
                     <Pin Id="GNESbHmJPlgPjHjRRgnYBr" Name="Mesh" Kind="InputPin" />
                     <Pin Id="A3unZzcQWy4MRihHLrHoNE" Name="Instance Count" Kind="InputPin" />
-                    <Pin Id="NtD18o9JjTZMJDHmwcAHCm" Name="Profiling Name" Kind="InputPin" />
                     <Pin Id="IxVek6ssT9XM4spVmgVcKf" Name="Topology" Kind="InputPin" />
                     <Pin Id="MDBMAysGX8MLOV68GTRJbS" Name="Draw Count" Kind="InputPin" />
                     <Pin Id="Uu7GOCO1v2AOdL7XazRY1M" Name="Output" Kind="StateOutputPin" />
@@ -5297,7 +5268,6 @@
                 <ProcessDefinition Id="RIg5a3wdpq9OejFiJOKFod">
                   <Fragment Id="RUfEdsCO2pZLC1phyVMaFB" Patch="KQ24aj6GzUUOjVV4RSi2eP" Enabled="true" />
                   <Fragment Id="Adglts67X1VQS5eh7hJ9Hp" Patch="V6vemOhlRmkMCNvLZLwMYD" Enabled="true" />
-                  <Fragment Id="ReDaGC6mvgcLBZjwn9Yl8x" Patch="CQZy1vXaigEMzmCYR4wlq4" />
                 </ProcessDefinition>
                 <Link Id="A77QaRiXdxoLoKwzzxdhzn" Ids="SZbTnQL8Kx1NHXrlNnu5Ve,V6cTJOcwcbKQM6CFPAH50a" />
                 <Link Id="URrsdQUORYrOQdkP9D61kM" Ids="IyQybxSajHYOwUFokR6yX7,SZbTnQL8Kx1NHXrlNnu5Ve" />
@@ -5322,7 +5292,6 @@
                 <Link Id="CuF2j5vWpkFM3Fklse1R2N" Ids="AmZr1hhMyZhOgzj69HxA9X,GNESbHmJPlgPjHjRRgnYBr" />
                 <Link Id="RhqQMJye8Z6QVV2uOTUUIy" Ids="VRNmfLjmtdrMuKM1MGjvug,FoJAIpYAyt4O5e50W6uUoK" IsHidden="true" />
                 <Link Id="Ltvii7k79kRNUEmTFFaTy7" Ids="FrUUe6UFPoEOzdAbvllJWs,CAhGGiiu2jBNsGIaNVUOre" />
-                <Patch Id="CQZy1vXaigEMzmCYR4wlq4" Name="CreateDefault (Hidden)" />
               </Patch>
             </Node>
             <!--
@@ -5951,19 +5920,22 @@
                 <Fragment Id="PTQQrPP43ifNIFi3Cn6AIu" Patch="FmoouCkb1T0Ly9chTnROLL" Enabled="true" />
                 <Fragment Id="DP5D9lw6sZyLi7TL9XMd6b" Patch="Rb0JiqDE3OxQVHhyascrRe" Enabled="true" />
                 <Fragment Id="CfJq6pwAQfrNpDLIdNQeA8" Patch="OR4m3UlTnbsNQ7cpXCSH2D" Enabled="true" />
-                <Fragment Id="U6JM6mvxfr3NNd968zSPQx" Patch="RzxT9tLVka8L4UULo63eWK" />
               </ProcessDefinition>
               <Link Id="I1J41Nev8V6M5i9vL9n6MC" Ids="Nztu1z0HfgqLLVVx6FEyJN,GXWiFulYw7mNgWwaAsxyhw" />
               <Link Id="EyZNxXoHX0nOIuR27njPql" Ids="NnVNuOhMTATLzjyPv83Eki,Nztu1z0HfgqLLVVx6FEyJN" IsHidden="true" />
               <Link Id="McSVtXw5qCMNEAZZMWFqJZ" Ids="FSC9iHU0EezN4tw89Zqc6j,HTSiOUPjvwROt0Jei9tOWL" />
               <Link Id="IvVobqB9eEsP3TZLdTci63" Ids="O0yASWc6bArPuJJsmisxaQ,LeKoF9DVpjFNXTRKb9obKE" />
+              <Link Id="TFmc1VCOBEBQDaQVbhN1w9" Ids="JYcbFuuGykQNzhkUgicnFl,GDslfCzI0SpL7xjLiOukkI" />
+              <Link Id="CPdOarwNnUhN5T8jQYOU5Q" Ids="G12wTLQp3eNNsHGgaLtEN0,Qm3JGSUgtbNNJjCnJT8Erz" />
+              <Link Id="Stp3O98LQJVOerXKtGQJ1L" Ids="VhMqYPasrNPPvRFlkm379n,EWmuELzkKJ9Muo0niEarNM" />
+              <Link Id="Saylkiuttw9P8HCwq5yEI5" Ids="II0kH61tWa5OUJrx8wmC3F,HI4nNKCymKyQI5X7FZkX18" />
               <Patch Id="IbcRwAT6MJNLGLwGiDs4af" Name="Create" />
               <Patch Id="FmoouCkb1T0Ly9chTnROLL" Name="Update">
                 <Pin Id="J3Vf7A79m0KOdnbdv1SU7Q" Name="Data" Kind="InputPin" />
                 <Pin Id="NnVNuOhMTATLzjyPv83Eki" Name="Update Buffer" Kind="InputPin" Bounds="640,169" />
                 <Pin Id="AmFb07c1dwCNjiIzNAXjq4" Name="Vertex Declaration" Kind="InputPin" />
                 <Pin Id="TrP4L4BnbukOuVke7ANc4L" Name="Topology" Kind="InputPin" Bounds="967,384" DefaultValue="TriangleList">
-                  <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastSymbolSource="VL.Stride.Graphics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl">
                     <Choice Kind="TypeFlag" Name="PrimitiveType" />
                   </p:TypeAnnotation>
                 </Pin>
@@ -5974,11 +5946,6 @@
               <Patch Id="Rb0JiqDE3OxQVHhyascrRe" Name="SetBoundingBox">
                 <Pin Id="UcAjOO9ry9EMmEwNI6d3qR" Name="Bounding Box" Kind="InputPin" Summary="Sets the bounding box, If not connected, it is set to the unit cube centered at the origin in obect sapce." />
               </Patch>
-              <Patch Id="RzxT9tLVka8L4UULo63eWK" Name="CreateDefault (Hidden)" />
-              <Link Id="TFmc1VCOBEBQDaQVbhN1w9" Ids="JYcbFuuGykQNzhkUgicnFl,GDslfCzI0SpL7xjLiOukkI" />
-              <Link Id="CPdOarwNnUhN5T8jQYOU5Q" Ids="G12wTLQp3eNNsHGgaLtEN0,Qm3JGSUgtbNNJjCnJT8Erz" />
-              <Link Id="Stp3O98LQJVOerXKtGQJ1L" Ids="VhMqYPasrNPPvRFlkm379n,EWmuELzkKJ9Muo0niEarNM" />
-              <Link Id="Saylkiuttw9P8HCwq5yEI5" Ids="II0kH61tWa5OUJrx8wmC3F,HI4nNKCymKyQI5X7FZkX18" />
             </Patch>
           </Node>
           <!--
@@ -6606,7 +6573,6 @@
                 <Fragment Id="TafHqhauojjM11ie4dnioa" Patch="JdHvHHGCY2mMJ3DJ8ybCUm" Enabled="true" />
                 <Fragment Id="VuNeNR9NmZdNSjPxGX6Jdj" Patch="QViTFElgbyyQd0Ji6SZXlf" Enabled="true" />
                 <Fragment Id="FUEh31O7tcpLEgdxtWHnJI" Patch="UQ9Sa5jP9NPL4RtlAkRsXT" Enabled="true" />
-                <Fragment Id="DW9cU08A9tyLlV1GUmWVc4" Patch="KdqkBMrN2OBP2gc4mFdgqa" />
               </ProcessDefinition>
               <Link Id="ATh99W1nStIQH8Vfw9qLn0" Ids="Bqrwpup2wVMLxue14LQYbW,Dvg9eo1AdCIQBg9aCrdWaB" />
               <Link Id="Su0zHgHuSXsNdIsaSvCibS" Ids="CxI33tSVTDsNRmmDF0hD3o,Q3uRkliMyUBQLsiVSkVbc6" IsHidden="true" />
@@ -6626,12 +6592,21 @@
               <Link Id="AKKshhkOrCwMSSsOKeNkhU" Ids="RqvYQSkFJ23LK46dnzcm74,NY8iB5gXMsEMOIfAgT3Xg2" />
               <Link Id="PmErbL99pT8MYjeJJNLalA" Ids="JdOalENlwEoOMcwQhmOASS,FBkZWLDYEpyPXtbqNSa3b4" />
               <Link Id="LK9jAmRHcRpNiyZr9GLy4O" Ids="JdOalENlwEoOMcwQhmOASS,TV0atIfdgrYQcLbi8ShtbB" />
+              <Link Id="KJWOZdIoM2kLOsF9ghxK8o" Ids="D5eFGOhAVXXLoBHSA3K8ZC,BHFXZrJO8LnNwf8h7lntYr" />
+              <Link Id="SZwdZgx8uGlLA0S1gSSi7v" Ids="PRyj6QuL0D8QCAduI1ADLk,CDJWJpRlMxxNC8NrH1sItd" />
+              <Link Id="D1AhjJTLUhJPVFx2XJ24Z8" Ids="G7MJGbuUvTMPd1U4UNl7Sv,Kc6NUSrSeetPAgtNen8sA9" />
+              <Link Id="B2LAsxcNtBfNdDatqbmY5h" Ids="DgipszXekxyNiq7HvlHl6B,G7MJGbuUvTMPd1U4UNl7Sv" IsHidden="true" />
+              <Link Id="NKnH88oXwDMOEgwuouJb0h" Ids="G7MJGbuUvTMPd1U4UNl7Sv,OL70HahTuKuPPs6VcN3XB6" />
+              <Link Id="EOdH4k94LxoOP41tDDL7PL" Ids="LRsIGAw8B8jMFea1pSSXIB,OZnKriXHIKEPYEJVPGzIvG" />
+              <Link Id="IPFhP6xtrIDNhWgfF1rW2s" Ids="LVa6UQ2wNdzNhlJ9f38cpg,Dx7ppqsnIM2N8D1jpAlT3X" />
+              <Link Id="OWiyUMxJnm0MSQ60942OMn" Ids="G7MJGbuUvTMPd1U4UNl7Sv,RVhvziFnBqEObh48WlJuIC" />
+              <Link Id="RxpqApy66AxQIIP1ukbuUY" Ids="LgEbNcfsmYULVM4t8rPxBr,N9BSsPrbSIdL9WuHjIYUzW" />
               <Patch Id="MNEYnc66M52LNRK4N8JvZf" Name="Create" />
               <Patch Id="JdHvHHGCY2mMJ3DJ8ybCUm" Name="Update">
                 <Pin Id="CxI33tSVTDsNRmmDF0hD3o" Name="Vertex Buffer" Kind="InputPin" Bounds="429,243" />
                 <Pin Id="Pj1wy1AJGnmQTxWC0zBkBP" Name="Vertex Declaration" Kind="InputPin" />
                 <Pin Id="NpNfwHbSYVQL1P1U4dunPD" Name="Topology" Kind="InputPin" Bounds="967,384" DefaultValue="TriangleList">
-                  <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastSymbolSource="VL.Stride.Graphics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl">
                     <Choice Kind="TypeFlag" Name="PrimitiveType" />
                   </p:TypeAnnotation>
                 </Pin>
@@ -6648,16 +6623,6 @@
               <Patch Id="QViTFElgbyyQd0Ji6SZXlf" Name="SetBoundingBox">
                 <Pin Id="R2OxN8rEgQRLsNT1UoZ1SF" Name="Bounding Box" Kind="InputPin" Summary="Sets the bounding box, If not connected, it is set to the unit cube centered at the origin in obect sapce." />
               </Patch>
-              <Patch Id="KdqkBMrN2OBP2gc4mFdgqa" Name="CreateDefault (Hidden)" />
-              <Link Id="KJWOZdIoM2kLOsF9ghxK8o" Ids="D5eFGOhAVXXLoBHSA3K8ZC,BHFXZrJO8LnNwf8h7lntYr" />
-              <Link Id="SZwdZgx8uGlLA0S1gSSi7v" Ids="PRyj6QuL0D8QCAduI1ADLk,CDJWJpRlMxxNC8NrH1sItd" />
-              <Link Id="D1AhjJTLUhJPVFx2XJ24Z8" Ids="G7MJGbuUvTMPd1U4UNl7Sv,Kc6NUSrSeetPAgtNen8sA9" />
-              <Link Id="B2LAsxcNtBfNdDatqbmY5h" Ids="DgipszXekxyNiq7HvlHl6B,G7MJGbuUvTMPd1U4UNl7Sv" IsHidden="true" />
-              <Link Id="NKnH88oXwDMOEgwuouJb0h" Ids="G7MJGbuUvTMPd1U4UNl7Sv,OL70HahTuKuPPs6VcN3XB6" />
-              <Link Id="EOdH4k94LxoOP41tDDL7PL" Ids="LRsIGAw8B8jMFea1pSSXIB,OZnKriXHIKEPYEJVPGzIvG" />
-              <Link Id="IPFhP6xtrIDNhWgfF1rW2s" Ids="LVa6UQ2wNdzNhlJ9f38cpg,Dx7ppqsnIM2N8D1jpAlT3X" />
-              <Link Id="OWiyUMxJnm0MSQ60942OMn" Ids="G7MJGbuUvTMPd1U4UNl7Sv,RVhvziFnBqEObh48WlJuIC" />
-              <Link Id="RxpqApy66AxQIIP1ukbuUY" Ids="LgEbNcfsmYULVM4t8rPxBr,N9BSsPrbSIdL9WuHjIYUzW" />
             </Patch>
           </Node>
           <Canvas Id="NmwNwmxAVNELdc2R4palVf" Name="Experimental" Position="636,220">
@@ -7345,7 +7310,6 @@
                 <ProcessDefinition Id="VXnNEMsSfCiNk0HngcKj6o">
                   <Fragment Id="QMSeBFSWt3wOCvNBUvXEZ8" Patch="HEJpfe3AQU9MgcpJ5UYbtI" Enabled="true" />
                   <Fragment Id="QHpzKGlbywjP9WjGp8pdeq" Patch="KjH9Cruid3NPjHctPK1oPF" Enabled="true" />
-                  <Fragment Id="JFBuhdsGTX0M8FgSlnAZZY" Patch="MoFPtp4gNICLi0A7RNe2UY" />
                 </ProcessDefinition>
                 <Link Id="FBmqFF63wc8LGsXckOPuKu" Ids="LuVHY51ulWmOYB6JbJsmxZ,RZKgDiYtRm6Ndj2SeMYV4S" />
                 <Link Id="IyZn98r0gWnMa3ZB4OrvU2" Ids="RzZNlh6S2PWNu8KNwOjRZf,FObCga3MdUkMbA6B1kHEPt" IsHidden="true" />
@@ -7468,7 +7432,6 @@
                 <Link Id="Ppn0sZL4KBMOzP39LfakZp" Ids="FzHtoGDKad6Lrosnh4i6Gz,LVQtji5ZkD5LIzCvEls2J6" />
                 <Link Id="F0gT4ZVUcXyOReGDU7gudQ" Ids="DYXrX6wmj5WNI3maTbiT9F,Okj8FMM0BSKMbW2tvAc4fP" />
                 <Link Id="HRsFopnnw9qPhwMK3meGAg" Ids="SB81AoPkQ4sMNXMBpvldaO,LlTIs6ibMpmL1qIyI5POMk" />
-                <Patch Id="MoFPtp4gNICLi0A7RNe2UY" Name="CreateDefault (Hidden)" />
                 <Link Id="GGjAuORVHEIN47wjy1yY4P" Ids="DJ4f5lFtiLROZcnLfV97ne,BONCAUgYPNmMEclSv1ZrEv" />
                 <Link Id="CxM718OuL3fPgenQYAWUnK" Ids="VRrn2yYJ97WM86nfnnNMvS,Vr4jqgfB9ehNijTOJFdBoI" />
                 <Link Id="L28L2I4tprjMZFk0XHyc1h" Ids="BfjUxvWuyqGORvkCmPT4wT,ANhUE58XvfmOsaE6S4xUqV" />
@@ -7949,7 +7912,6 @@
                   <Fragment Id="Gs025QEaR3INUZrfRmxMj9" Patch="NoI0XYh1z3HNtqwqGN9aIR" Enabled="true" />
                   <Fragment Id="TuCHwX50vtbPHliQhRwcGk" Patch="TlL5jFarL6vLIzvT2e2hAI" />
                   <Fragment Id="SxwMcx7fqQpL5ihPN1eKII" Patch="EAlVNDIYMg6LauLtN4deDN" />
-                  <Fragment Id="CpYbjMIYK4VNPnQXWYpWbf" Patch="QbExudl6LA6NdyGykRMSk8" />
                 </ProcessDefinition>
                 <Link Id="LFl1QxFxKQRO5U4z4qCjPI" Ids="JgtK14IXkHFNIrFEsNUcTE,EwbYHyiRrvnPddg7pw7D55" IsHidden="true" />
                 <Link Id="AIWRNPLTZD3NvPUeaT3cub" Ids="EwbYHyiRrvnPddg7pw7D55,NEm4BnVfAbFPxuT5cSYk4Y" />
@@ -8001,7 +7963,6 @@
                   <Pin Id="DEzkSYGBd1kOlyamkwBhr2" Name="Primitive Type" Kind="OutputPin" Bounds="30,958" />
                   <Pin Id="JWZLWDO09ewLyQJk1AMjgG" Name="IndexBuffer Is 32Bit" Kind="OutputPin" Bounds="554,954" />
                 </Patch>
-                <Patch Id="QbExudl6LA6NdyGykRMSk8" Name="CreateDefault (Hidden)" />
               </Patch>
             </Node>
             <!--
@@ -9029,7 +8990,6 @@
                 <ProcessDefinition Id="DBmIHJF8NtjQdcjX2LoSyn">
                   <Fragment Id="D3OwgfHqWC4NvGsNwNKNPo" Patch="GluHOI8uVGzOw6GwYpHsit" Enabled="true" />
                   <Fragment Id="JvBujmfjoDRQGleYUeN98Y" Patch="IbHh3eJ6cXHMfFOpt387Vo" Enabled="true" />
-                  <Fragment Id="TEVLCn9g2viQNP7G1Vqr8t" Patch="Cf7bvdXH83pOVScEQg1Rca" />
                 </ProcessDefinition>
                 <Link Id="HiGp9g9NbbnPQr1uvI6dEX" Ids="KhwK3iZSnZlLA1zRIRdUDi,KoKZQjIsPLhNiFC5JP6vDA" />
                 <Link Id="FJKu43P6U8wOVUqNfIvWYz" Ids="DTZqyreC9BmOx6PbuJ71pN,OUt2oUB6wkIODCBjuRnoXt" IsHidden="true" />
@@ -9116,7 +9076,6 @@
                 <Link Id="HNE9DCLvPLwLkMptezNWTA" Ids="BSmvMPqmhsOO2MOI34xwwH,SUDQWS1ryRlLYZtK3CQBfp" />
                 <Link Id="Q25hKSQ7eclPJtIiJbWrn0" Ids="B3dnSdyeklrOcGo4kWsJIX,KLzjKbdfvhONEDBKkknfXq" />
                 <Link Id="UgjLk9LHI49NJhGJreAyWY" Ids="QhOgXPdibyeMhcnx6kHgdg,AasVlXcnEsoO5oPuRswqFT" />
-                <Patch Id="Cf7bvdXH83pOVScEQg1Rca" Name="CreateDefault (Hidden)" />
                 <Link Id="A6SXpfxsNOlNeejqbZQQUd" Ids="IHbVIfsQtfxNsqnEX1Effc,B1pA1LzVVnUPIkidecRoS6" />
                 <Link Id="R1yHcW5fCUUP3ok6qF2Mm0" Ids="AfLiJzU8vmSPe80kZMEQTr,REXDSQ5m6EKLVDokKtWWJe" />
                 <Link Id="AcWZlrTVfotNS8qNg2yLCY" Ids="UkWfnWD4pbpNChu8cajI7M,BVobUkuIvkyPYryAw8kXDZ" />
@@ -9696,7 +9655,6 @@
                 <ProcessDefinition Id="MPpXUkA9cDBNJdXLGBBWMN">
                   <Fragment Id="D0ydDm76P8mPiSucrnTc7z" Patch="UAEiklI9NhdL8snKzSGpMY" Enabled="true" />
                   <Fragment Id="CTzBpqLeLL1QSAp4B20FPQ" Patch="JGOyLIDacLHPiNmrGmNBjj" Enabled="true" />
-                  <Fragment Id="P5XO40IfnK1Lh8rwZAlx34" Patch="SkcRJuIM0mmQKvOnzvuwXI" />
                 </ProcessDefinition>
                 <Link Id="P8dc4Xyt4naLzjZaET5BvH" Ids="DSzaLnI8hygN3qRdEgIu9A,E6dyymVKIvEPMNYRbRCfgq" />
                 <Link Id="C463xZGZWPdLUi9HgEeyD2" Ids="U04n1h2gUxeOhJzbiCer5Z,V5OYtl6aVWwONHUO5oaFyt" IsHidden="true" />
@@ -9797,7 +9755,6 @@
                 <Link Id="FkOy7AzpxomPeKLoQpzUGe" Ids="MUTXNWP2MPxQavXxN2OOTf,Otj7v0jvSveLTiT7TrWOhi" />
                 <Link Id="UT7N4uIuhk9OfKVE71yWlN" Ids="BU35OWnagk0P2lFX1jtZtl,TP8aBidmNKHOiYxtlOpcdn" />
                 <Link Id="UbZr2TRWKdTOIT5VBFNL2D" Ids="EaVPBKntaeZMjhzrqNCG58,NQkbl42QnMgObvkbwYrq4Q" />
-                <Patch Id="SkcRJuIM0mmQKvOnzvuwXI" Name="CreateDefault (Hidden)" />
                 <Link Id="LJatlCjIUGNP4EmZ0RKCR0" Ids="CAL8foWkuStM50m0696eRA,RDJQuwNqHM9NcgcfuSwqI7" />
                 <Link Id="S98HRRHkgUCOTE0OOJqQBy" Ids="HDfwEqRdi07PS2PKyjWvDC,FGPQVyh24QoLepVgof1B9c" />
                 <Link Id="MV8exNFcDAuMzbYFFhc3a6" Ids="DwZ87jVuuyuPNdSshlTtdf,KY1rOVTbRukNcAR4fZ2eaY" />
@@ -10253,20 +10210,22 @@
                 <Fragment Id="IhKHMUWIKMWNPvtlBylOc1" Patch="PnVicVZCexMQRDLGZJkf7o" Enabled="true" />
                 <Fragment Id="Dzj98ZT58GjP0GHrM8joJ1" Patch="JmynNNnCM8TLlwYHhgt8n2" Enabled="true" />
                 <Fragment Id="PV6sNLDiIZVPF43NBiQlud" Patch="JmqfQQPPaDsOHOX2IDrOFT" Enabled="true" />
-                <Fragment Id="N8AloOiQ1pnMZqyWIRHU4c" Patch="I1VeCGhuQ8gO9mJsp1Apk2" />
               </ProcessDefinition>
               <Link Id="CVmX78qoyebNV6mtToZqZH" Ids="L6YdPZYhQF3QbwSLi67Nce,BANUUg2NFBCNiiiYC4Ahug" />
               <Link Id="O8MDgSGd0PaMrltuocSP8p" Ids="HCEoDQ7TD3LQFRlwBVLL8l,L6YdPZYhQF3QbwSLi67Nce" IsHidden="true" />
               <Link Id="E6mHqCw17unPrzasfmscsU" Ids="HBluF9qusgAPzhYFmyvrcI,ASsHuXnJVG1On6HmhQIlEe" />
               <Link Id="FaYfllzsc9kOBCyUsD0WyX" Ids="FFVPCjGa0RnPP2tuZpCuKD,Hpf6m8iH9zSLYn6x6lqjw4" />
               <Link Id="U2jloAuh2dZO9AeWB4HxNc" Ids="IAemMiA4AytNW44t2pdWMR,SHiAr5tVilFMIqoZtykWHC" />
+              <Link Id="ByL31sQRmk5NDZpRCtEh7o" Ids="QyOGYiQAGBxN6OxFKiQ2rm,OZeIOcMhhU1OmK7XLIv0Nj" />
+              <Link Id="Fxr5Eu3ZdBpQNaG61WKSho" Ids="OPQX1WBPf6qOYT12DtrPap,HUDSkBYGVX3MElm25W9sd8" />
+              <Link Id="CSKpKKa5ETCPLKXnpV5w2u" Ids="VudVKwSJncJOIFacfNRwJi,BJWVqbKwGi1LYrBsGFAnDV" />
               <Patch Id="Iu8IQvSLbk5N87MEuOwzMt" Name="Create" />
               <Patch Id="PnVicVZCexMQRDLGZJkf7o" Name="Update">
                 <Pin Id="SO1VkKvpHeBL5gM6MsXDj4" Name="Data" Kind="InputPin" />
                 <Pin Id="HCEoDQ7TD3LQFRlwBVLL8l" Name="Update Buffer" Kind="InputPin" Bounds="640,169" />
                 <Pin Id="RmNFTwNsGe4NmFy9jILXX0" Name="Vertex Declaration" Kind="InputPin" />
                 <Pin Id="S4KaoNOlYHiPPPVvpFEqUq" Name="Topology" Kind="InputPin" Bounds="967,384" DefaultValue="TriangleList">
-                  <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastSymbolSource="VL.Stride.Graphics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl">
                     <Choice Kind="TypeFlag" Name="PrimitiveType" />
                   </p:TypeAnnotation>
                 </Pin>
@@ -10278,10 +10237,6 @@
               <Patch Id="JmynNNnCM8TLlwYHhgt8n2" Name="SetBoundingBox">
                 <Pin Id="HKRUh4REyyzLPw0mT1GlvS" Name="Bounding Box" Kind="InputPin" Summary="Sets the bounding box, If not connected, it is set to the unit cube centered at the origin in obect sapce." />
               </Patch>
-              <Patch Id="I1VeCGhuQ8gO9mJsp1Apk2" Name="CreateDefault (Hidden)" />
-              <Link Id="ByL31sQRmk5NDZpRCtEh7o" Ids="QyOGYiQAGBxN6OxFKiQ2rm,OZeIOcMhhU1OmK7XLIv0Nj" />
-              <Link Id="Fxr5Eu3ZdBpQNaG61WKSho" Ids="OPQX1WBPf6qOYT12DtrPap,HUDSkBYGVX3MElm25W9sd8" />
-              <Link Id="CSKpKKa5ETCPLKXnpV5w2u" Ids="VudVKwSJncJOIFacfNRwJi,BJWVqbKwGi1LYrBsGFAnDV" />
             </Patch>
           </Node>
         </Canvas>
@@ -11088,7 +11043,6 @@
             <ProcessDefinition Id="I52mmC7i34BNCzOiQCJdOY">
               <Fragment Id="PIJgd15141NMcENPVWF8bK" Patch="I8Y6oFCidmzN2Rc9sUQHnd" Enabled="true" />
               <Fragment Id="Um9LGkwTq0hP6ceAxS5jGS" Patch="TA7RFs244WtPHwitDIrMsp" Enabled="true" />
-              <Fragment Id="FKm2gt4aSMDP7FoPGfU5zJ" Patch="B9y816l6JbUMA3j6pHoOde" />
             </ProcessDefinition>
             <Link Id="P6WCyvFTjWOPnZODajiAwm" Ids="ENRagQ1KXQINdYEMM4bFzj,Oy0HC7g6yG6NKu9SqKFDr2" />
             <Link Id="NMLWQHd3MUJP9E7HERsBKX" Ids="G1IbLhmeUikN5x1Hb212DI,VoMiLb9om41NkdaYt7rnhy" IsFeedback="true" />
@@ -11124,7 +11078,6 @@
               <Pin Id="DCpvxEHmUKSNFLFmmeE3b4" Name="First Mesh" Kind="OutputPin" Bounds="514,550" />
               <Pin Id="MDaQYxKQpr6NAaS8aDYmuD" Name="Meshes" Kind="OutputPin" Bounds="595,550" />
             </Patch>
-            <Patch Id="B9y816l6JbUMA3j6pHoOde" Name="CreateDefault (Hidden)" />
           </Patch>
         </Node>
       </Canvas>
@@ -11229,36 +11182,7 @@
               <ControlPoint Id="JGmspHGMv6iL7Gf1uY6ubq" Bounds="390,715" />
               <ControlPoint Id="GQqZ33My0gnMiaoxl6XfNt" Bounds="340,-42" />
               <ControlPoint Id="Pk9JruP63PvN83D2hsw6JD" Bounds="19,855" />
-              <Node Bounds="1046,-152,83,72" Id="EbUQTUUcUigLuFUe7Gsqja">
-                <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
-                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                  <Choice Kind="ProcessStatefulRegion" Name="Cache" />
-                  <CategoryReference Kind="Category" Name="Primitive" />
-                </p:NodeReference>
-                <Pin Id="GGD4pjhh1KfPaQrX6JCoes" Name="Force" Kind="InputPin" />
-                <Pin Id="VOvW6ujh2SnOE5txZEpo9y" Name="Dispose Cached Outputs" Kind="InputPin" />
-                <Pin Id="PfS2Y7OpVLPNbsT1L1tyJ7" Name="Has Changed" Kind="OutputPin" />
-                <Patch Id="Bbu9EnVDuXlNzpM0Hvp8Al" ManuallySortedPins="true">
-                  <Patch Id="Sw4RBrKy75gN5fzN14X2Oa" Name="Create" ManuallySortedPins="true" />
-                  <Patch Id="IjSrGICQihiPrZmFivB9Gz" Name="Then" ManuallySortedPins="true" />
-                  <Node Bounds="1058,-128,59,26" Id="LOxMrPtC9LONZ58xRaqsTC">
-                    <p:NodeReference LastCategoryFullName="Stride.Core.Diagnostics.ProfilingKey" LastSymbolSource="VL.Stride.Core.vl">
-                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                      <CategoryReference Kind="Category" Name="Stride" />
-                      <CategoryReference Kind="Category" Name="Core" />
-                      <CategoryReference Kind="Category" Name="Diagnostics" />
-                      <CategoryReference Kind="ClassType" Name="ProfilingKey" />
-                      <Choice Kind="OperationCallFlag" Name="Create" />
-                    </p:NodeReference>
-                    <Pin Id="EEp00hkLWRQLWf8PgvMUsb" Name="Name" Kind="InputPin" />
-                    <Pin Id="PgdwnyUCkIWNjuan7xlLHm" Name="Flags" Kind="InputPin" />
-                    <Pin Id="CL2ap6PmnciNi6ubpAk5ZS" Name="Output" Kind="StateOutputPin" />
-                  </Node>
-                </Patch>
-                <ControlPoint Id="JbwrBo9YDJ6PKdP2FbprFR" Bounds="1060,-146" Alignment="Top" />
-                <ControlPoint Id="D1q7hVFPnoBNjCW6rPqWaZ" Bounds="1060,-86" Alignment="Bottom" />
-              </Node>
-              <ControlPoint Id="Kf7yTzGuu65LlJe1gRLs5y" Bounds="1060,-175" />
+              <ControlPoint Id="Kf7yTzGuu65LlJe1gRLs5y" Bounds="1020,-123" />
               <Node Bounds="952,22,70,26" Id="TlDh1z5KhuEMIXR4PwzFV7">
                 <p:NodeReference LastCategoryFullName="Stride.Rendering.QueryManager" LastSymbolSource="Stride.Rendering.dll">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -11296,7 +11220,6 @@
                 <Pin Id="IECJB9IEpyDNzNl4HY52oY" Name="Input" Kind="StateInputPin" />
                 <Pin Id="Fe7wJlBiJWrN4V8qlCs71S" Name="Output" Kind="StateOutputPin" />
               </Node>
-              <Pad Id="DloBmlnehYaOFPKHF7qVrS" Bounds="1060,-56" />
               <Node Bounds="338,-25,88,26" Id="GoUxHnmky9ZK9oRAy1Y6BW">
                 <p:NodeReference LastCategoryFullName="Stride.API.Rendering.RenderDrawContext" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -11900,6 +11823,15 @@
                 </p:NodeReference>
                 <Pin Id="IKbQyNbESfQPO5DGN16GwJ" Name="Instance" Kind="OutputPin" />
               </Node>
+              <Node Bounds="1018,-82,71,19" Id="VQMJ8EqjsQxOyG9pQuc3Ti">
+                <p:NodeReference LastCategoryFullName="Stride.API.Core.Diagnostics" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="ProfilingKey" />
+                </p:NodeReference>
+                <Pin Id="JQ2LvCNzoi3LYLLt8mD1np" Name="Name" Kind="InputPin" />
+                <Pin Id="EQoS5qY6f2KQOrME4rwwPx" Name="Flags" Kind="InputPin" />
+                <Pin Id="NOar2dWCRywOPNnnABnNrN" Name="Key" Kind="OutputPin" />
+              </Node>
             </Canvas>
             <Slot Id="F5RZvbXwigsPQwXQPlrm3p" Name="Effect" />
             <Link Id="GhUeGGcqAQyONW2HdpKesp" Ids="E6taK1WUS3QLNWhIdilOxU,DWru2uqXCOwNXIheB4EyoK" IsFeedback="true" />
@@ -11917,21 +11849,16 @@
             <Link Id="J73QMBvPJwkPHKrgRKeU3H" Ids="GQqZ33My0gnMiaoxl6XfNt,IexShgVcgMtLJrPo9RUaU4" />
             <Link Id="Rs5Jibh42zhOaXBsBU5ePE" Ids="MSa0vbu3rdTPZVCAUE1pfU,AxpMfZQFHPNQbXUpJSvWk3" />
             <Link Id="CysPOoYXfQnOGU8fxV2Dem" Ids="MSa0vbu3rdTPZVCAUE1pfU,Pk9JruP63PvN83D2hsw6JD,MKRihi827FRNu4YkcGpT0j" />
-            <Link Id="BBjWgk2JMjIMN5XsQlwgNU" Ids="Kf7yTzGuu65LlJe1gRLs5y,JbwrBo9YDJ6PKdP2FbprFR" />
-            <Link Id="OouppKhRl4dPYTmrBdWosi" Ids="URuzTFzwyuQLxY1xnJRokB,Kf7yTzGuu65LlJe1gRLs5y" IsHidden="true" />
-            <Link Id="RTHSKrALkxRLgJnTSTl65A" Ids="D1q7hVFPnoBNjCW6rPqWaZ,DloBmlnehYaOFPKHF7qVrS" />
+            <Link Id="OouppKhRl4dPYTmrBdWosi" Ids="TMaP6JpDfiwPIlGJbulo7x,Kf7yTzGuu65LlJe1gRLs5y" IsHidden="true" />
             <Link Id="UT3E6XZozCQQDSBb9uxYBt" Ids="Jp9jGcl1m8EQcPOActpeTZ,Ks58tr6RyrcLIG9VHK5NNh" IsFeedback="true" />
             <Link Id="GkZTEUHoXLTOvCyV71RlGT" Ids="LFZ7pzBH3JBPww6wvrahkh,KmEmF084zf7NYDPTPOOtU7" IsFeedback="true" />
             <Link Id="GR87bFHzLnrM5R85kwqB50" Ids="KmEmF084zf7NYDPTPOOtU7,IECJB9IEpyDNzNl4HY52oY" />
             <Link Id="IDgj90uMZAfLgv4Jbrtvt8" Ids="SEQFKe2tPw2Lc9cE3UCNdt,LFZ7pzBH3JBPww6wvrahkh" />
-            <Link Id="OchIB9Yh37RLl8qvLJKnQ0" Ids="DloBmlnehYaOFPKHF7qVrS,Oazip7UjC2kNCsx3g3rq0L" />
             <Link Id="Mb2xjBKGoAWLkh4fyLIkHA" Ids="DILaQ1515EcQEPtL64dCwF,PT7tz4BZ1guPKvlNgWnDjn" />
             <Link Id="GkEtOWw0zknPEhQTZi31B0" Ids="IcpH4q94FgoOWJqE8OhJaB,RLXwzPFDp8ELj8AqwSVHMq" IsFeedback="true" />
             <Link Id="QFWI3f0qFN4PDrGJ5TXFgx" Ids="O1xmH57zbp7NvUsntbJYPt,IcpH4q94FgoOWJqE8OhJaB" />
             <Link Id="GU0tJBSdTVJLkhao4WFtNq" Ids="B4JYKWnKNuPNDVYfc3iyJP,BwsDWjL5mqAQadbrHPrBPq" IsFeedback="true" />
             <Link Id="GZskl1rbimZNc6cPKgg4A3" Ids="Gtgd2zo5WGjMvF4WDjNwrC,B4JYKWnKNuPNDVYfc3iyJP" />
-            <Link Id="SGKyqzHY04TMDJkF6PVzAb" Ids="JbwrBo9YDJ6PKdP2FbprFR,EEp00hkLWRQLWf8PgvMUsb" />
-            <Link Id="RzjXo89Z8aBPcziz1xI2aK" Ids="CL2ap6PmnciNi6ubpAk5ZS,D1q7hVFPnoBNjCW6rPqWaZ" />
             <Link Id="P55tTahVxlhNPjvfjaebXg" Ids="AmRIvXR7JUsPLvQ2fSpRPa,NexkPaiJzpyNepbAlRuUgZ" />
             <Link Id="CLh7nCDm93INd3fRZtRE61" Ids="CppDun7MLr8MH6jyzC3R07,ThjKSXPa1LONNo9UEccmn9" />
             <Link Id="O8OgNjJV5CjM75XepWqWAV" Ids="E9YUgF0Y53qLMwM1RG7eye,GQqZ33My0gnMiaoxl6XfNt" IsHidden="true" />
@@ -12005,11 +11932,16 @@
               <Fragment Id="JwqML83un7mQFOUkNIE1N7" Patch="JALQvp8VNqxL5WureejbLH" Enabled="true" />
               <Fragment Id="MPqqQtdMc99OotVdRGCC4K" Patch="Vl9Ntd8iTAlLAV04rs6PxW" Enabled="true" />
               <Fragment Id="IXKLzKTNbMqLDzjCmtPk70" Patch="A84xMAe0y0hPblGnKbLgDM" />
-              <Fragment Id="GG2NPzaDWvoOmXivJAkHWj" Patch="PucwgiXUsIcN8r3qz5UXWO" />
             </ProcessDefinition>
             <Link Id="SvBijbbT7UEM63OaJToyEX" Ids="JGmspHGMv6iL7Gf1uY6ubq,MVI6RmkCk99PKcw5HY65lw" />
             <Link Id="ND7L4Pb1R3IOUMuFQnNWnt" Ids="MVI6RmkCk99PKcw5HY65lw,KSl52m2IOj6NyKkGcTMsNx" />
-            <Patch Id="V0KgeDkOLRSQY3xQn3FaYc" Name="Create" />
+            <Patch Id="V0KgeDkOLRSQY3xQn3FaYc" Name="Create">
+              <Pin Id="TMaP6JpDfiwPIlGJbulo7x" Name="Profiling Name" Kind="InputPin" DefaultValue="Mesh Renderer" Visibility="Optional">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <Choice Kind="TypeFlag" Name="String" />
+                </p:TypeAnnotation>
+              </Pin>
+            </Patch>
             <Patch Id="CpkAaz8C4S8PhMX3c56enI" Name="DrawInternal" ParticipatingElements="JqhonSHTcCLLMkTTUT8EuF,ThWx1ZiPDgtN265sGibuTC">
               <Pin Id="E9YUgF0Y53qLMwM1RG7eye" Name="Context" Kind="InputPin" />
             </Patch>
@@ -12018,11 +11950,6 @@
               <Pin Id="JzAPPB2V2CVOHSBEQkPgxw" Name="Instance Count" Kind="InputPin" DefaultValue="1">
                 <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
-                </p:TypeAnnotation>
-              </Pin>
-              <Pin Id="URuzTFzwyuQLxY1xnJRokB" Name="Profiling Name" Kind="InputPin" DefaultValue="Mesh Renderer">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                  <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
             </Patch>
@@ -12061,7 +11988,8 @@
             <Link Id="U0XNACJquMvNP0ey22A8Z9" Ids="GSsTfMPmdNpLcb9aX7nXFr,GdF9XtbGRcfPRUcOScFwvm" />
             <Link Id="PrDqywxT4ixO5MX61jkeYl" Ids="IKbQyNbESfQPO5DGN16GwJ,UIScNXwkWCvMTPvOVVhZbk" />
             <Link Id="KXFveVVJXfINOuR3DxBj5B" Ids="B5bWUzPIk7ZQCDk3O4yYFL,LadlsrSm8RsMZspvCELmiQ" />
-            <Patch Id="PucwgiXUsIcN8r3qz5UXWO" Name="CreateDefault (Hidden)" />
+            <Link Id="E9mmnI7dHXULFQ5MR9SzyD" Ids="Kf7yTzGuu65LlJe1gRLs5y,JQ2LvCNzoi3LYLLt8mD1np" />
+            <Link Id="C6PrxEiFiOmNnPp9cDEvrq" Ids="NOar2dWCRywOPNnnABnNrN,Oazip7UjC2kNCsx3g3rq0L" />
           </Patch>
         </Node>
         <!--
@@ -12601,7 +12529,6 @@
               <Fragment Id="Qe0S1MczDWBOLildNGFiap" Patch="LhhgeuBjJBwL0SINQjgxKd" Enabled="true" />
               <Fragment Id="RKPscxVAYHFMUjDsfQrroU" Patch="KRPdv0b8vABM5OWO8QPRoj" />
               <Fragment Id="BhjVo7hdii9P6Siq8Yn34t" Patch="USxioTZ0cyoMmzv3Bxrzlc" Enabled="true" />
-              <Fragment Id="Q2TGODo8HSUM66eVBQH1I9" Patch="I4u3ImYC0NjLQZpvrOIKdz" />
             </ProcessDefinition>
             <Link Id="BXoCXxpl47SLDL8zC3j6L8" Ids="IR7kvmbc48VMCkj8sWJZ36,TKmpuWtfpvjNrxtJHlhU1T" />
             <Link Id="S5boJzCpgdHLwI6uWghJIA" Ids="NVefxremZcONIE10n5NTR9,TFkJlSdrY9oMEBUNW4UxA4" />
@@ -12648,7 +12575,6 @@
               <Pin Id="Sllu1VzR6ZQPpu6uivDAwR" Name="Success" Kind="OutputPin" />
               <Pin Id="L7tzeORJsS3NSuTPijfPCv" Name="Destination" Kind="OutputPin" />
             </Patch>
-            <Patch Id="I4u3ImYC0NjLQZpvrOIKdz" Name="CreateDefault (Hidden)" />
           </Patch>
         </Node>
         <!--
@@ -12784,7 +12710,7 @@
                         <Pin Id="Kc82qosOcEOPUV7BISLUyT" Name="Output" Kind="StateOutputPin" />
                       </Node>
                       <Node Bounds="668,560,31,26" Id="TA4vd7LbWwROIjZVnyJh9Q">
-                        <p:NodeReference LastCategoryFullName="Stride.API.Core.Mathematics.Int2" LastSymbolSource="VL.Stride.Core.vl">
+                        <p:NodeReference LastCategoryFullName="Primitive.Int2" LastSymbolSource="CoreLibBasics.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="RecordType" Name="Int2" />
                           <Choice Kind="OperationCallFlag" Name="X" />
@@ -12895,7 +12821,7 @@
                         <Pin Id="TVfi45UNUqSPIXKrtqtNvM" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="717,562,31,26" Id="NXnlPA5FzcSMfoeaKp1YDM">
-                        <p:NodeReference LastCategoryFullName="Stride.API.Core.Mathematics.Int2" LastSymbolSource="VL.Stride.Core.vl">
+                        <p:NodeReference LastCategoryFullName="Primitive.Int2" LastSymbolSource="CoreLibBasics.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="RecordType" Name="Int2" />
                           <Choice Kind="OperationCallFlag" Name="Y" />
@@ -13925,13 +13851,13 @@
               <Link Id="ILAZbOdHP9uLleoQ2TgSx0" Ids="Uje7LkF3CUWM1x4vkXyYD2,LgHGSsccRQ8OClmNUkZlXj" />
               <Link Id="V7175Og2VfeLhWji51a5X4" Ids="QmJnTv1tyA0Ow4M7f0yAM9,RvXz4tOorM6QbXKpgKzzTT" />
               <Pin Id="I2vn1mq3btKPpsfKBNKVqT" Name="Count" Kind="InputPin" Bounds="425,323" />
-              <Pin Id="DNy4ga4FC6jLkubJYQsNlx" Name="Thread Group Count" Kind="OutputPin" Bounds="427,538" />
-              <Pin Id="LpsyL226Y7OOEOytsEny9n" Name="Thread Group Size" Kind="OutputPin" Bounds="507,539" />
               <Pin Id="Qa6Ifpm3uqdMwtruSf5rVT" Name="Thread Group Size" Kind="InputPin" Bounds="561,242" DefaultValue="8, 8">
-                <p:TypeAnnotation LastCategoryFullName="Stride.API.Core.Mathematics" LastSymbolSource="VL.Stride.Core.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Int2" />
                 </p:TypeAnnotation>
               </Pin>
+              <Pin Id="DNy4ga4FC6jLkubJYQsNlx" Name="Thread Group Count" Kind="OutputPin" Bounds="427,538" />
+              <Pin Id="LpsyL226Y7OOEOytsEny9n" Name="Thread Group Size" Kind="OutputPin" Bounds="507,539" />
             </Patch>
           </Node>
           <!--
@@ -14272,13 +14198,13 @@
               <Link Id="PSmPNl5A1b7PGANz8L5iAu" Ids="Jaa4oUfdCsSQRACibKAJCz,CC45nP4LqAXORVQmuubJRk" />
               <Link Id="Roqk6sQUbvSN1IjWtZgwO1" Ids="DyjXWwRFapPOYO3sHwzRKT,UqqNLDdJZKSMLU4Ec7d4s2" />
               <Pin Id="EVHg4tU5FNxONbSUUuzTeT" Name="Count" Kind="InputPin" Bounds="425,323" />
-              <Pin Id="FmX7CWinXXrOYv0InjuHhE" Name="Thread Group Count" Kind="OutputPin" Bounds="427,538" />
-              <Pin Id="RGxtml1toSHMJbLUmnvAG3" Name="Thread Group Size" Kind="OutputPin" Bounds="507,539" />
               <Pin Id="ACi9RABzkviQaQzPZ4rVXS" Name="Thread Group Size" Kind="InputPin" Bounds="561,242" DefaultValue="4, 4, 4">
-                <p:TypeAnnotation LastCategoryFullName="Stride.API.Core.Mathematics" LastSymbolSource="VL.Stride.Core.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Int3" />
                 </p:TypeAnnotation>
               </Pin>
+              <Pin Id="FmX7CWinXXrOYv0InjuHhE" Name="Thread Group Count" Kind="OutputPin" Bounds="427,538" />
+              <Pin Id="RGxtml1toSHMJbLUmnvAG3" Name="Thread Group Size" Kind="OutputPin" Bounds="507,539" />
             </Patch>
           </Node>
           <!--
@@ -14375,7 +14301,7 @@
               <Link Id="H8CbV6ay25XNeKORqyYSg8" Ids="HVoJpU5D54cLP476OP52ks,LJbLHT7qKDmNE9fYPkYVl8" />
               <Link Id="MX5fxCwN7BDMeL9aohOMwV" Ids="Ar5DuEYnPiMOiEYZS76nEH,M2Otjp7lehlMy4yieM93cF" />
               <Pin Id="GbUjmdvIJtpNOWlDdTHnbR" Name="Thread Group Size" Kind="InputPin" Bounds="561,242" DefaultValue="8, 8">
-                <p:TypeAnnotation LastCategoryFullName="Stride.API.Core.Mathematics" LastSymbolSource="VL.Stride.Core.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Int2" />
                 </p:TypeAnnotation>
               </Pin>
@@ -14510,7 +14436,7 @@
               <Link Id="OZmfRA9JmmwPMxfZtlJXRG" Ids="TN6RwNz14MfNxPvl5YquEF,EbwZA6kn8Q1MBCp60a9So9" />
               <Link Id="MJvnfpPvcuVMth7H6lgCcl" Ids="EG633UbiXKgNVDcuBgGhn5,PFRGYhWhuy3Lr26qCEs8t2" />
               <Pin Id="JuwDYbiZzg9NhMH3KDoRgU" Name="Thread Group Size" Kind="InputPin" Bounds="561,242" DefaultValue="4, 4, 4">
-                <p:TypeAnnotation LastCategoryFullName="Stride.API.Core.Mathematics" LastSymbolSource="VL.Stride.Core.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Int3" />
                 </p:TypeAnnotation>
               </Pin>
@@ -14963,13 +14889,17 @@
             <Link Id="GrALcO6W9ChOHulRYKbXPH" Ids="Cy7f6X2tt71LrqwbhAv7v5,N6eo0WTs3R4NPSovWVGFUe" />
             <Link Id="PVPkgYS93uQPozkFHybJO6" Ids="PSkk6iHSTDbMMxFfRKaRLO,TjjRd4t4lxMPiw4sDFNx3y" />
             <Link Id="VveqctX5zauQNGGQSeFgqW" Ids="HQUGzV3OmW7OKn9dS9Fgts,TTQYuYgLMH6PoRQhUFY1w9" />
+            <Link Id="HmrPKG4GiqCO30F2XLxxRM" Ids="GhNX1M7boa9NO1gGSc9eUk,L72fPDDfP9wLkqbqX8FPkW" />
+            <Link Id="Knj0rHvluMCLSwZyDS9cFs" Ids="GhNX1M7boa9NO1gGSc9eUk,I8tAws2TOPeMnbLbbMLqxB" />
+            <Link Id="BqLiVdq5airPR6ChuYgSK5" Ids="QizJyXIaT6bPs8q19tTrHw,JsrZiXKFdudP0Gwc5PPLlR" />
+            <Link Id="AmRgrQqz9bDMUdraUvd8o9" Ids="ASF23JGgtrxMgHxSWXHdft,CRzYFxJUFAiObqACkQA6i2" />
             <Patch Id="Ns5hkbcJmQ5NPr3QhZz6ZO" Name="Create" ParticipatingElements="BG0PpJy93XHLGwqPeAikxd" />
             <Patch Id="Fdr0wXfFCFgQcDIAuDiWe1" Name="Update" ManuallySortedPins="true">
               <Pin Id="BUJGRrG5VB2LdQlQqXI5Rc" Name="Input" Kind="InputPin" />
               <Pin Id="O19OGsbyyODQbGCTpztTvV" Name="Frame Delay" Kind="InputPin" />
               <Pin Id="U9GtXm16JuDLViHVQPljQy" Name="Size" Kind="InputPin" Bounds="783,224" Summary="If 0, the input size is used. Otherwise the texture will be resized." />
               <Pin Id="HzuNmF0BNvZMjQBEQbLp2v" Name="New Format" Kind="InputPin" Bounds="787,487" DefaultValue="R8G8B8A8_UNorm_SRgb" Summary="The read back pixel format to write into the image">
-                <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastSymbolSource="VL.Stride.Graphics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl">
                   <Choice Kind="TypeFlag" Name="PixelFormat" />
                 </p:TypeAnnotation>
               </Pin>
@@ -14978,10 +14908,6 @@
               <Pin Id="GR6DsxM1JwFLDorQcoAyE2" Name="Readback Time" Kind="OutputPin" />
             </Patch>
             <Patch Id="DSRa6mNxXYbOJlS0ATQTt4" Name="Dispose" />
-            <Link Id="HmrPKG4GiqCO30F2XLxxRM" Ids="GhNX1M7boa9NO1gGSc9eUk,L72fPDDfP9wLkqbqX8FPkW" />
-            <Link Id="Knj0rHvluMCLSwZyDS9cFs" Ids="GhNX1M7boa9NO1gGSc9eUk,I8tAws2TOPeMnbLbbMLqxB" />
-            <Link Id="BqLiVdq5airPR6ChuYgSK5" Ids="QizJyXIaT6bPs8q19tTrHw,JsrZiXKFdudP0Gwc5PPLlR" />
-            <Link Id="AmRgrQqz9bDMUdraUvd8o9" Ids="ASF23JGgtrxMgHxSWXHdft,CRzYFxJUFAiObqACkQA6i2" />
           </Patch>
         </Node>
         <!--
@@ -15441,7 +15367,6 @@
             <ProcessDefinition Id="HerWV16f52HOZVWdc9nt7R">
               <Fragment Id="SYtOi8PQpJCN2GrpsRtmjK" Patch="GQ0X1OHSVtyM5zx4NRA15J" Enabled="true" />
               <Fragment Id="ELP4idZ8KrpO2Luxl7IpsL" Patch="FuIoUKw7B7RNMLGUsalupF" Enabled="true" />
-              <Fragment Id="GVACsaVBsS4LYXSqyMbpFZ" Patch="Iz6ftcUYIJ9NNySHYebR4e" />
             </ProcessDefinition>
             <Link Id="TpQrUVptF6hOXXTbSA3j8u" Ids="DAkC7dlrzBsM0EZ4mTpZhY,Ky8YU1gLzvTMNytYCFLY7v" IsHidden="true" />
             <Link Id="LAravRztryRLhnIJOOktSw" Ids="Ky8YU1gLzvTMNytYCFLY7v,IbC5ILG5FnRO8LB2c2z4gq" />
@@ -15477,7 +15402,6 @@
               <Pin Id="KNAiWuXvlYnOmGVpf7bufJ" Name="Renderer" Kind="OutputPin" Bounds="326,359" Visibility="Optional" />
               <Pin Id="Bmown6V883YORBslRUHyXO" Name="Output" Kind="OutputPin" Bounds="545,342" />
             </Patch>
-            <Patch Id="Iz6ftcUYIJ9NNySHYebR4e" Name="CreateDefault (Hidden)" />
           </Patch>
         </Node>
         <!--
@@ -16230,7 +16154,6 @@
             <ProcessDefinition Id="G91u3nHH2mnQa4BFEQ7VjD">
               <Fragment Id="BSfchGJG7SZPVDNttmLmbT" Patch="PnwuHAi8wa1PnGTFhhP7r5" Enabled="true" />
               <Fragment Id="V7ClQXEqdeFOkXH1aEvHPA" Patch="K2YSvbXvlvBLpASogy8lcc" Enabled="true" />
-              <Fragment Id="Mh0KZqGZvQVMQgatIrp2GU" Patch="CgmqyvXwJrrQDJFKbQKEv4" />
             </ProcessDefinition>
             <Link Id="EUtqV5dE2TLPBvMXWVavTO" Ids="CIQE74dZ5v9LQmnDg5HbqB,OOhugTZjA2gP2eE52LH8J0" />
             <Link Id="KQhjPYiO23uPooAPbdLeP3" Ids="Rf5h0ENXS1RPEOkeeGgIgy,CIQE74dZ5v9LQmnDg5HbqB" IsHidden="true" />
@@ -16257,7 +16180,6 @@
                 </p:TypeAnnotation>
               </Pin>
             </Patch>
-            <Patch Id="CgmqyvXwJrrQDJFKbQKEv4" Name="CreateDefault (Hidden)" />
           </Patch>
         </Node>
         <!--
@@ -16454,7 +16376,6 @@
             <ProcessDefinition Id="MQULUKljo2aPIDVutyhw4m">
               <Fragment Id="Kx5aapw2hAQQPhdEM7jxjP" Patch="CePmIWMAHuOMIuSz4ZjCq3" Enabled="true" />
               <Fragment Id="GCsVrO6mFRmLAFqJqngWcu" Patch="ROka7MOjQg5QVckivKo1Ll" Enabled="true" />
-              <Fragment Id="VEOdb4SqXYFPJGQDJTlZXf" Patch="SD530IBsPHoP4dyr7yBK0N" />
             </ProcessDefinition>
             <Link Id="NsjwkVB1W2XNpLgoyXFKZQ" Ids="KYudZxA7zG5PKjjBjEJZs4,HWYV2LSRZ0XQKPSrHegk6m" IsHidden="true" />
             <Link Id="Huf9e1y1ubrMUNMbaHouWH" Ids="CFD0o3i18PcP9BzB2ymEBT,L7K7EI3TbvgOhuBbkGpZ9W" IsHidden="true" />
@@ -16508,7 +16429,6 @@
               <Pin Id="EVWZMf9Is7bPADRxUOOhky" Name="Output" Kind="OutputPin" Bounds="545,342" />
               <Pin Id="UnOqFIcWRoBMdXXe6vi9a1" Name="Shared Handle" Kind="OutputPin" Bounds="634,377" />
             </Patch>
-            <Patch Id="SD530IBsPHoP4dyr7yBK0N" Name="CreateDefault (Hidden)" />
           </Patch>
         </Node>
       </Canvas>
@@ -17096,12 +17016,12 @@
   <PlatformDependency Id="Rmk1hhUSQ4uOQmsJAH5lsU" Location="Stride.Core.Mathematics.dll" />
   <PlatformDependency Id="Tc8NoUSn0SuMMBZAUjprPJ" Location="Stride.Rendering.dll" />
   <PlatformDependency Id="CszHwhDkPr3NhEtP3Djfl7" Location="Stride.Graphics.dll" />
-  <NugetDependency Id="EkUWkHqtRXcQVEg26rgBpq" Location="VL.Core" Version="2021.4.0-0171-gf5b4947bff" />
+  <NugetDependency Id="EkUWkHqtRXcQVEg26rgBpq" Location="VL.Core" Version="2021.4.0-0192-g8d2005b8ce" />
   <DocumentDependency Id="GgJFG0lRV0ZOQUkVvPG0vL" Location="./VL.Stride.Games.vl" />
   <PlatformDependency Id="ARsp3DhFm9mL1X4DOx1Vtm" Location="Stride.Games.dll" />
   <PlatformDependency Id="MwArYn0D5CiNAmmLjqaRgA" Location="Stride.dll" />
   <PlatformDependency Id="Q7nST93Js7JPC6j1sTV9L9" Location="Stride.Core.dll" />
-  <NugetDependency Id="EjPOOnYIHFTPiEWYlANtiy" Location="VL.UI.Core" Version="2021.4.0-0171-gf5b4947bff" />
+  <NugetDependency Id="EjPOOnYIHFTPiEWYlANtiy" Location="VL.UI.Core" Version="2021.4.0-0192-g8d2005b8ce" />
   <DocumentDependency Id="UObWgh0LBvhOQjw1GfoR4z" Location="./VL.Stride.Input.vl" IsFriend="true" />
   <NodeFactoryDependency Id="G8f0R8c6bNHPPJESeWChtz" Location="VL.Stride.Rendering.Nodes" IsForward="true" />
   <NodeFactoryDependency Id="T4XjgRvHD6SOaL2LXA4EBL" Location="VL.Stride.Rendering.EffectShaderNodes" IsForward="true" />

--- a/packages/VL.Stride.Runtime/VL.Stride.Runtime.TypeForwards.vl
+++ b/packages/VL.Stride.Runtime/VL.Stride.Runtime.TypeForwards.vl
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="TiJxb2oN2LtNWRy2MbJV6Q" LanguageVersion="2021.4.0.183" Version="0.128">
-  <NugetDependency Id="LpDzfnL2ypqNzyyOieWuHI" Location="VL.CoreLib" Version="2021.4.0-0171-gf5b4947bff" />
+<Document xmlns:p="property" Id="TiJxb2oN2LtNWRy2MbJV6Q" LanguageVersion="2021.4.0.194" Version="0.128">
+  <NugetDependency Id="LpDzfnL2ypqNzyyOieWuHI" Location="VL.CoreLib" Version="2021.4.0-0192-g8d2005b8ce" />
   <PlatformDependency Id="JJ0ZRRgadtbPuisZUaeinf" Location="Stride.Graphics.dll" />
-  <NugetDependency Id="RUpxj8weM25L4I4AlKb6Yw" Location="VL.Core" Version="2021.4.0-0171-gf5b4947bff" />
+  <NugetDependency Id="RUpxj8weM25L4I4AlKb6Yw" Location="VL.Core" Version="2021.4.0-0192-g8d2005b8ce" />
   <PlatformDependency Id="IC8TlSKr9KnNYjdQ1ni0yJ" Location="Stride.dll" />
   <PlatformDependency Id="IzFXsvic9e0LQG5m2Qejqv" Location="../VL.Stride.Tests/src/bin/Debug/net472/Stride.Core.Mathematics.dll" />
   <NodeFactoryDependency Id="RQuja2dHYIeLUbtM4bRWNa" Location="VL.Stride.Graphics.Nodes" IsForward="true" />
@@ -4545,24 +4545,6 @@
           <Canvas Id="PNjkz0DyiHqNNqqzmPH9cM" Name="Diagnostics" Position="352,228">
             <!--
 
-    ************************ ProfilingKey ************************
-
--->
-            <Node Name="ProfilingKey" Bounds="437,228" Id="MFO2tP6BLyJQYGF6JfWHXu">
-              <p:NodeReference>
-                <Choice Kind="ForwardDefinition" Name="Forward" />
-                <FullNameCategoryReference ID="Primitive" />
-              </p:NodeReference>
-              <p:TypeAnnotation LastCategoryFullName="Stride.Core.Diagnostics" LastSymbolSource="Stride.Core.dll">
-                <Choice Kind="TypeFlag" Name="ProfilingKey" />
-              </p:TypeAnnotation>
-              <Patch Id="VqbmdTepOGfLFkARx4Mo5q">
-                <Canvas Id="OLoup4oPcKgO9itGioEI2S" CanvasType="Group" />
-                <ProcessDefinition Id="N5PSfyTBZZrLEM5ndBllXw" IsHidden="true" />
-              </Patch>
-            </Node>
-            <!--
-
     ************************ Logger ************************
 
 -->
@@ -4595,6 +4577,102 @@
               <Patch Id="SNlhonmnedGNMp6FCHUPC5">
                 <Canvas Id="FbWoMBNzvOUL8fGsIhDU1G" BordersChecked="false" CanvasType="Group" />
                 <ProcessDefinition Id="FonzRiqhHx5NsXnZEKYuXd" IsHidden="true" />
+              </Patch>
+            </Node>
+            <!--
+
+    ************************ ProfilingKey ************************
+
+-->
+            <Node Name="ProfilingKey" Bounds="435,224" Id="KQSVGH9vGHLO5Z7ThE46fT">
+              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+                <Choice Kind="ContainerDefinition" Name="Process" />
+              </p:NodeReference>
+              <Patch Id="QwXtb6qA1kdQSPTsTDPtVd">
+                <Canvas Id="KO6GCFx70zMNufRqtAVgqt" CanvasType="Group">
+                  <Node Bounds="560,216,83,126" Id="PpdmuHXvPSZOKjZNlsCPGr">
+                    <p:NodeReference LastCategoryFullName="System.Resources" LastSymbolSource="CoreLibBasics.vl">
+                      <Choice Kind="OperationCallFlag" Name="NewPooled (PerApp)" />
+                      <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
+                    </p:NodeReference>
+                    <Pin Id="SaLOqF2XYmsLD5WByuFPrl" Name="Key" Kind="InputPin" />
+                    <Pin Id="Lo2HyqSF5G4MPA6eX8z70D" Name="Delay Disposal In Milliseconds" Kind="InputPin" />
+                    <Pin Id="TQlX7Ln2RmtOPS0KPXaWva" Name="Result" Kind="OutputPin" />
+                    <Patch Id="PgB6V4bUeSiLGZ6Vfyqfnb" Name="Factory" ManuallySortedPins="true">
+                      <Pin Id="BDgRC6YfQTiQdWSrut8V04" Name="Input" Kind="InputPin" />
+                      <Pin Id="VskvU2X96hfLtDYYk1vnnX" Name="Result" Kind="OutputPin" />
+                      <ControlPoint Id="KC6r1i718LmMZGpMK7iiCJ" Bounds="574,224" />
+                      <ControlPoint Id="JneolOVpmVRODfw3MFJw9s" Bounds="574,335" />
+                      <Node Bounds="572,282,59,26" Id="OD0yxcHEQUiNiV75PFf94d">
+                        <p:NodeReference LastCategoryFullName="Stride.Core.Diagnostics.ProfilingKey" LastSymbolSource="Stride.Core.dll">
+                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                          <Choice Kind="OperationCallFlag" Name="Create" />
+                          <CategoryReference Kind="AssemblyCategory" Name="ProfilingKey" NeedsToBeDirectParent="true" />
+                        </p:NodeReference>
+                        <Pin Id="R3q2d9NgdilOr1iby66xOU" Name="Name" Kind="InputPin" />
+                        <Pin Id="DuIIp8LsQ1gLgMKBtXOpI1" Name="Flags" Kind="InputPin" />
+                        <Pin Id="DGAH8TEeOXQOl7YTkwT8AA" Name="Output" Kind="StateOutputPin" />
+                      </Node>
+                      <Node Bounds="572,243,36,19" Id="MDg1zY1xtbDPdHwRhwuQsS">
+                        <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (2 Items)" LastSymbolSource="CoreLibBasics.vl">
+                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                          <CategoryReference Kind="RecordType" Name="ValueTuple (2 Items)" />
+                          <Choice Kind="OperationCallFlag" Name="Split" />
+                        </p:NodeReference>
+                        <Pin Id="UFVWgfQd7lrPgPIcPxr9dG" Name="Input" Kind="StateInputPin" />
+                        <Pin Id="VQFeQoN5cgTOqQEV1q8oKX" Name="Item 1" Kind="OutputPin" />
+                        <Pin Id="KmWwGJo7JEcPyUVeVbO1Ai" Name="Item 2" Kind="OutputPin" />
+                      </Node>
+                    </Patch>
+                  </Node>
+                  <ControlPoint Id="Su1yurClAqIMDywtn5faB9" Bounds="562,138" />
+                  <ControlPoint Id="EJWLqM7L0nvLsBzHO9jHtt" Bounds="561,429" />
+                  <Node Bounds="560,172,90,26" Id="TTnUuy8FDWMMRRnZZEXg9F">
+                    <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (2 Items)" LastSymbolSource="CoreLibBasics.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="RecordType" Name="ValueTuple (2 Items)" />
+                      <Choice Kind="OperationCallFlag" Name="Create" />
+                    </p:NodeReference>
+                    <Pin Id="CxL73vapCvmOVzZg17IcXG" Name="Item 1" Kind="InputPin" />
+                    <Pin Id="KQUdG5zWQ8ZOKc9KukjGjB" Name="Item 2" Kind="InputPin" />
+                    <Pin Id="CLtCGugpAcLO63QiQ8bcXP" Name="Output" Kind="StateOutputPin" />
+                  </Node>
+                  <ControlPoint Id="KS8B5mdKzEDMtRj21LTzJc" Bounds="647,139" />
+                  <Node Bounds="560,373,42,19" Id="TQbs6yStjoWM8fuJXgd5PZ">
+                    <p:NodeReference LastCategoryFullName="System.Resources" LastSymbolSource="CoreLibBasics.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="ProcessAppFlag" Name="Using (Process)" />
+                    </p:NodeReference>
+                    <Pin Id="SxoeK6ITwquL1Vc7Yn9i3y" Name="Input" Kind="InputPin" />
+                    <Pin Id="SSDng7k6QKMNZq5LXmlc9p" Name="Resource" Kind="OutputPin" />
+                  </Node>
+                </Canvas>
+                <Patch Id="LMN8cUEntY7N2VsseHIkZ0" Name="Create">
+                  <Pin Id="QdvGuP8NWD6QNJB28hMaPk" Name="Name" Kind="InputPin" />
+                  <Pin Id="N2wuE6zKnEOQJyr8gWCXcZ" Name="Flags" Kind="InputPin" />
+                </Patch>
+                <Patch Id="KJ5cQsaReE9P9KAA2P96cr" Name="Update">
+                  <Pin Id="DAg2zmoScxHLqYvHn7O13G" Name="Key" Kind="OutputPin" Bounds="729,525" />
+                </Patch>
+                <ProcessDefinition Id="AZHZCA54SEzO0U26rOAs6T">
+                  <Fragment Id="ScQBEmPUDE3OIEbc5Rxiwh" Patch="LMN8cUEntY7N2VsseHIkZ0" Enabled="true" />
+                  <Fragment Id="NEQpaX4g1YKP1SYjJa9T12" Patch="KJ5cQsaReE9P9KAA2P96cr" Enabled="true" />
+                </ProcessDefinition>
+                <Link Id="P4IyjMdw45MLNyGlvX2YO5" Ids="BDgRC6YfQTiQdWSrut8V04,KC6r1i718LmMZGpMK7iiCJ" IsHidden="true" />
+                <Link Id="GQwwsenYMEqM7fp7N5ySJW" Ids="JneolOVpmVRODfw3MFJw9s,VskvU2X96hfLtDYYk1vnnX" IsHidden="true" />
+                <Link Id="TGItZW2QVAQMGoMF4TKIE2" Ids="DGAH8TEeOXQOl7YTkwT8AA,JneolOVpmVRODfw3MFJw9s" />
+                <Link Id="G445g54vWW4PKoa3By2uk7" Ids="QdvGuP8NWD6QNJB28hMaPk,Su1yurClAqIMDywtn5faB9" IsHidden="true" />
+                <Patch Id="COIp3pUND68LnkIQaY4lNF" Name="Dispose" />
+                <Link Id="L7qJue4iB0BOpVjgUPV0uE" Ids="EJWLqM7L0nvLsBzHO9jHtt,DAg2zmoScxHLqYvHn7O13G" IsHidden="true" />
+                <Link Id="CJTaBilXPrHOlTZYHtfKjF" Ids="VQFeQoN5cgTOqQEV1q8oKX,R3q2d9NgdilOr1iby66xOU" />
+                <Link Id="I7l2FxIW3GJNtS5OQZxl5G" Ids="KC6r1i718LmMZGpMK7iiCJ,UFVWgfQd7lrPgPIcPxr9dG" />
+                <Link Id="P40OMZolBlTOT66MWKyols" Ids="Su1yurClAqIMDywtn5faB9,CxL73vapCvmOVzZg17IcXG" />
+                <Link Id="UdTEMQxxq2APZwKnlBOXg3" Ids="N2wuE6zKnEOQJyr8gWCXcZ,KS8B5mdKzEDMtRj21LTzJc" IsHidden="true" />
+                <Link Id="EhhBnAHDm2CNznlbMttO3Z" Ids="KS8B5mdKzEDMtRj21LTzJc,KQUdG5zWQ8ZOKc9KukjGjB" />
+                <Link Id="BcGaw1w4BTEPwJFTtFKSr5" Ids="CLtCGugpAcLO63QiQ8bcXP,SaLOqF2XYmsLD5WByuFPrl" />
+                <Link Id="VY0wdZrViz4N7OkRrkJF45" Ids="KmWwGJo7JEcPyUVeVbO1Ai,DuIIp8LsQ1gLgMKBtXOpI1" />
+                <Link Id="SZMzkKuxlZVOtvxzL840pr" Ids="TQlX7Ln2RmtOPS0KPXaWva,SxoeK6ITwquL1Vc7Yn9i3y" />
+                <Link Id="G6mB41xRkBVNrHG6dfBszc" Ids="SSDng7k6QKMNZq5LXmlc9p,EJWLqM7L0nvLsBzHO9jHtt" />
               </Patch>
             </Node>
           </Canvas>


### PR DESCRIPTION
Replaces the plain `ProfilingKey` type forward with a process node which manages the lifetime of the key through the resource pool per application entry point. Creating instances of the type directly immediately leads to a potential memory leak as they get added to an internal static hash set. Just exposing the process node will prevent that from happening all together.

## Related issues
#476