### PR TITLE
Material Extensions Rework

### DIFF
--- a/packages/VL.Stride.Runtime/VL.Stride.Rendering.vl
+++ b/packages/VL.Stride.Runtime/VL.Stride.Rendering.vl
@@ -9797,10 +9797,10 @@
               </p:NodeReference>
               <Patch Id="BTg1blPbEOUNpLUFboXPqo">
                 <Canvas Id="AJDsXpjkJB6Lx02hDPJrUJ" CanvasType="Group">
-                  <ControlPoint Id="Qd5VYcSDwOgN77w6yKfYuF" Bounds="926,223" />
-                  <ControlPoint Id="LT5V9TqbxaWNzA5HG0msbW" Bounds="944,1019" />
-                  <ControlPoint Id="DNfL7rKQT98Ot6QqYnQREt" Bounds="1011,223" />
-                  <Node Bounds="942,968,42,19" Id="FxVPXsGQm17PUXgmvI3oZM">
+                  <ControlPoint Id="Qd5VYcSDwOgN77w6yKfYuF" Bounds="246,168" />
+                  <ControlPoint Id="LT5V9TqbxaWNzA5HG0msbW" Bounds="264,964" />
+                  <ControlPoint Id="DNfL7rKQT98Ot6QqYnQREt" Bounds="331,168" />
+                  <Node Bounds="262,913,42,19" Id="FxVPXsGQm17PUXgmvI3oZM">
                     <p:NodeReference LastCategoryFullName="System.Resources" LastSymbolSource="CoreLibBasics.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="Using (Process)" />
@@ -9808,7 +9808,7 @@
                     <Pin Id="B3nL1V1tSk7MrX5FUWfhlT" Name="Input" Kind="InputPin" />
                     <Pin Id="BGU4sn45EvAOWrwTYQONt9" Name="Resource" Kind="OutputPin" />
                   </Node>
-                  <Node Bounds="876,280,1200,660" Id="PPEGGkjiOQJMYJSlRaWvdF">
+                  <Node Bounds="196,225,1200,660" Id="PPEGGkjiOQJMYJSlRaWvdF">
                     <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                       <Choice Kind="ProcessStatefulRegion" Name="Cache" />
@@ -9817,16 +9817,16 @@
                     <Pin Id="GpUlZcVo9EJQR0HvVDy9Qx" Name="Force" Kind="InputPin" />
                     <Pin Id="LXn02Aobrm5M6279Bh2UIa" Name="Dispose Cached Outputs" Kind="InputPin" />
                     <Pin Id="PE8WZBgpFN5LXRgqkdAIjn" Name="Has Changed" Kind="OutputPin" />
-                    <ControlPoint Id="TrkBKnvb2qSNbfCLeNSmZS" Bounds="926,306" Alignment="Top" />
-                    <ControlPoint Id="LXD08twdhmUOscCrRyLnVR" Bounds="944,934" Alignment="Bottom" />
-                    <ControlPoint Id="Vw81fURsBcTN2PbxEyT889" Bounds="1011,306" Alignment="Top" />
-                    <ControlPoint Id="ED0zfHw0yLOQKgHAqI3y90" Bounds="1096,306" Alignment="Top" />
-                    <ControlPoint Id="Ixu5KFxVDvTPGHGLlREPCA" Bounds="1219,286" Alignment="Top" />
-                    <ControlPoint Id="MpypzXKJb6SPsz5yWjaQ0N" Bounds="1324,286" Alignment="Top" />
+                    <ControlPoint Id="TrkBKnvb2qSNbfCLeNSmZS" Bounds="246,231" Alignment="Top" />
+                    <ControlPoint Id="LXD08twdhmUOscCrRyLnVR" Bounds="264,879" Alignment="Bottom" />
+                    <ControlPoint Id="Vw81fURsBcTN2PbxEyT889" Bounds="331,231" Alignment="Top" />
+                    <ControlPoint Id="ED0zfHw0yLOQKgHAqI3y90" Bounds="416,231" Alignment="Top" />
+                    <ControlPoint Id="Ixu5KFxVDvTPGHGLlREPCA" Bounds="539,231" Alignment="Top" />
+                    <ControlPoint Id="MpypzXKJb6SPsz5yWjaQ0N" Bounds="644,231" Alignment="Top" />
                     <Patch Id="HkUgkwUOt0wMQl7L0Lrxa7" ManuallySortedPins="true">
                       <Patch Id="Ey2ESMqS1J3O8nUHzRMOC5" Name="Create" ManuallySortedPins="true" />
                       <Patch Id="T3neN6yUpVVO3ynkdNy9yO" Name="Then" ManuallySortedPins="true" />
-                      <Node Bounds="942,384,1122,508" Id="NkPVASx76QNP43IG4zUg5S">
+                      <Node Bounds="262,329,1122,508" Id="NkPVASx76QNP43IG4zUg5S">
                         <p:NodeReference LastCategoryFullName="System.Resources" LastSymbolSource="CoreLibBasics.vl">
                           <Choice Kind="OperationCallFlag" Name="NewPooled (PerApp)" />
                           <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
@@ -9837,9 +9837,9 @@
                         <Patch Id="OdE5buRN4iDNlyCp0q1juI" Name="Factory" ManuallySortedPins="true">
                           <Pin Id="DODaQuazim9NhNYP7I3qSs" Name="Input" Kind="InputPin" />
                           <Pin Id="QDon7Y9kOdeM3FKVYU5BDJ" Name="Result" Kind="OutputPin" />
-                          <ControlPoint Id="ODRvnTdjrhMLL5FGAYeOp5" Bounds="1107,392" />
-                          <ControlPoint Id="VnQMNySSpxuMk14nyGqFtZ" Bounds="958,874" />
-                          <Node Bounds="1105,413,732,19" Id="MmoI3EgahiXPS3xa1Yq5kz">
+                          <ControlPoint Id="ODRvnTdjrhMLL5FGAYeOp5" Bounds="427,337" />
+                          <ControlPoint Id="VnQMNySSpxuMk14nyGqFtZ" Bounds="278,819" />
+                          <Node Bounds="425,358,732,19" Id="MmoI3EgahiXPS3xa1Yq5kz">
                             <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (5 Items)" LastSymbolSource="CoreLibBasics.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="Split" />
@@ -9852,7 +9852,7 @@
                             <Pin Id="SbbXgtwWYwXLxwF5WZF3lT" Name="Item 4" Kind="OutputPin" />
                             <Pin Id="Aehyqhx9gynNGiLmKyVDD1" Name="Item 5" Kind="OutputPin" />
                           </Node>
-                          <Node Bounds="1261,846,92,26" Id="UmyiTcAalBJMXChhdMGK1y">
+                          <Node Bounds="581,791,92,26" Id="UmyiTcAalBJMXChhdMGK1y">
                             <p:NodeReference LastCategoryFullName="Stride.Rendering.MeshDraw" LastSymbolSource="Stride.Rendering.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="AssemblyCategory" Name="MeshDraw" />
@@ -9862,7 +9862,7 @@
                             <Pin Id="Q8KzIaiDvmPNa9fMV6zgh2" Name="Value" Kind="InputPin" />
                             <Pin Id="CPP6OwHVEgxNAeD4Exlh0V" Name="Output" Kind="StateOutputPin" />
                           </Node>
-                          <Node Bounds="1348,810,64,26" Id="EW0w6GfjvUgQdYphht71U1">
+                          <Node Bounds="668,755,64,26" Id="EW0w6GfjvUgQdYphht71U1">
                             <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableArray" LastSymbolSource="VL.Collections.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="ToArray" />
@@ -9871,7 +9871,7 @@
                             <Pin Id="JjWPtOftSe2NYRCF2vaLVp" Name="Input" Kind="InputPin" />
                             <Pin Id="GFdQ3WCom5BQXqNAhaE3hz" Name="Result" Kind="OutputPin" />
                           </Node>
-                          <Node Bounds="1348,770,88,26" Id="VX57Nr89HpAMKUpVBI1Brh">
+                          <Node Bounds="668,715,88,26" Id="VX57Nr89HpAMKUpVBI1Brh">
                             <p:NodeReference LastCategoryFullName="Stride.Graphics.VertexBufferBinding" LastSymbolSource="Stride.Graphics.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="AssemblyCategory" Name="VertexBufferBinding" />
@@ -9888,7 +9888,7 @@
                             <Pin Id="NIRezSDL6hIQFpb27Pr0iV" Name="Vertex Offset" Kind="InputPin" />
                             <Pin Id="BaVAXzR38CfNj4EvTXSQdN" Name="Output" Kind="StateOutputPin" />
                           </Node>
-                          <Node Bounds="1018,641,53,26" Id="BxJDwi0L5iANOPbTPSMN5L">
+                          <Node Bounds="338,586,53,26" Id="BxJDwi0L5iANOPbTPSMN5L">
                             <p:NodeReference LastCategoryFullName="Stride.Rendering.MeshDraw" LastSymbolSource="Stride.Rendering.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="AssemblyCategory" Name="MeshDraw" />
@@ -9896,7 +9896,7 @@
                             </p:NodeReference>
                             <Pin Id="BNeR9cuvdEyNAAHmKbaOz8" Name="Output" Kind="StateOutputPin" />
                           </Node>
-                          <Node Bounds="955,698,53,26" Id="IQouOHXnMZxMZVfP8N0JG0">
+                          <Node Bounds="275,643,53,26" Id="IQouOHXnMZxMZVfP8N0JG0">
                             <p:NodeReference LastCategoryFullName="Stride.API.Rendering.Mesh" LastSymbolSource="VL.Stride.Runtime.CSharpImport.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="ClassType" Name="Mesh" />
@@ -9906,7 +9906,7 @@
                             <Pin Id="LyuWvuutq6gLEH1nRouIgG" Name="Value" Kind="InputPin" />
                             <Pin Id="PBfK0yoAmSQLjsrza2Xiaz" Name="Output" Kind="StateOutputPin" />
                           </Node>
-                          <Node Bounds="954,557,46,26" Id="FGkepUvIw2AMJFkPphBZEj">
+                          <Node Bounds="274,502,46,26" Id="FGkepUvIw2AMJFkPphBZEj">
                             <p:NodeReference LastCategoryFullName="Stride.API.Rendering.Mesh" LastSymbolSource="VL.Stride.Runtime.CSharpImport.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="ClassType" Name="Mesh" />
@@ -9914,7 +9914,7 @@
                             </p:NodeReference>
                             <Pin Id="KA8ce7k8MfUPnKr0FEFkFb" Name="Output" Kind="StateOutputPin" />
                           </Node>
-                          <Node Bounds="954,609,90,26" Id="QPAPnW2b5JtOB8rWT5miES">
+                          <Node Bounds="274,554,90,26" Id="QPAPnW2b5JtOB8rWT5miES">
                             <p:NodeReference LastCategoryFullName="Stride.Rendering.Mesh" LastSymbolSource="Stride.Rendering.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="SetBoundingBox" />
@@ -9924,7 +9924,7 @@
                             <Pin Id="PTdqXOpSFE3QBqUgfoF7Px" Name="Value" Kind="InputPin" />
                             <Pin Id="KC0QzzDKAAHOihh8WBaRXR" Name="Output" Kind="StateOutputPin" />
                           </Node>
-                          <Node Bounds="1369,730,67,19" Id="DBse2yFZw87LFLxH3RA8k3">
+                          <Node Bounds="689,675,67,19" Id="DBse2yFZw87LFLxH3RA8k3">
                             <p:NodeReference LastCategoryFullName="Stride.API.Graphics.VertexDeclaration" LastSymbolSource="VL.Stride.Runtime.CSharpImport.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="ClassType" Name="VertexDeclaration" />
@@ -9932,7 +9932,7 @@
                             </p:NodeReference>
                             <Pin Id="VoJ5HlGEssUPCW7ofB8Hu1" Name="Output" Kind="StateOutputPin" />
                           </Node>
-                          <Node Bounds="1348,699,45,19" Id="Gq4EjrG6SMnL4DaXpD9EJR">
+                          <Node Bounds="668,644,45,19" Id="Gq4EjrG6SMnL4DaXpD9EJR">
                             <p:NodeReference LastCategoryFullName="Stride.Graphics.Buffer.Vertex" LastSymbolSource="Stride.Graphics.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="AssemblyCategory" Name="Vertex" />
@@ -9951,7 +9951,7 @@
                             <Pin Id="T9aVMJcf6NOLzds9qMfEN6" Name="Usage" Kind="InputPin" />
                             <Pin Id="T3F6JBpBi18OfrnXvWJ0EA" Name="Result" Kind="OutputPin" />
                           </Node>
-                          <Node Bounds="1368,663,64,26" Id="AeCIlGiK8pZO6A4QnntdYA">
+                          <Node Bounds="688,608,64,26" Id="AeCIlGiK8pZO6A4QnntdYA">
                             <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableArray" LastSymbolSource="VL.Collections.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="ArrayType" Name="MutableArray" />
@@ -9960,13 +9960,13 @@
                             <Pin Id="RRyJEOPPTLbPehUlDk9KBg" Name="Input" Kind="StateInputPin" />
                             <Pin Id="LCwzl6u21oOOd8a5KJG0nN" Name="Result" Kind="OutputPin" />
                           </Node>
-                          <Pad Id="IPkF3ShcxNxMrZDzQMvPXX" Comment="Input" Bounds="1370,597,35,57" ShowValueBox="true" isIOBox="true" Value="0, 0, 0, 1">
+                          <Pad Id="IPkF3ShcxNxMrZDzQMvPXX" Comment="Input" Bounds="690,542,35,57" ShowValueBox="true" isIOBox="true" Value="0, 0, 0, 1">
                             <p:TypeAnnotation>
                               <Choice Kind="TypeFlag" Name="Vector4" />
                               <FullNameCategoryReference ID="3D" />
                             </p:TypeAnnotation>
                           </Pad>
-                          <Node Bounds="1029,720,81,26" Id="Ahuf2KmQghmPLT6og8ziYr">
+                          <Node Bounds="349,665,81,26" Id="Ahuf2KmQghmPLT6og8ziYr">
                             <p:NodeReference LastCategoryFullName="Stride.API.Rendering.MeshDraw" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="ClassType" Name="MeshDraw" />
@@ -9976,7 +9976,7 @@
                             <Pin Id="KTJnUhsqZhTLSKjwr6HIUt" Name="Value" Kind="InputPin" />
                             <Pin Id="JNfn6oGBaCENhme2HvdkDS" Name="Output" Kind="StateOutputPin" />
                           </Node>
-                          <Node Bounds="1046,796,91,26" Id="R9i710N4hBvOpHnjNVBILF">
+                          <Node Bounds="366,741,91,26" Id="R9i710N4hBvOpHnjNVBILF">
                             <p:NodeReference LastCategoryFullName="Stride.API.Rendering.MeshDraw" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="ClassType" Name="MeshDraw" />
@@ -9986,7 +9986,7 @@
                             <Pin Id="U5mQWgJH0K6NovojVx59Xf" Name="Value" Kind="InputPin" />
                             <Pin Id="BCFWV60M4nZORsUq6tHNPJ" Name="Output" Kind="StateOutputPin" />
                           </Node>
-                          <Node Bounds="1027,514,148,78" Id="QTKu0HPbAhVN2xhGqCGE5u">
+                          <Node Bounds="347,459,148,78" Id="QTKu0HPbAhVN2xhGqCGE5u">
                             <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
                               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                               <Choice Kind="ApplicationStatefulRegion" Name="If" />
@@ -9996,7 +9996,7 @@
                             <Patch Id="AWOZi2rdBFFPtwmPuMmf7t" ManuallySortedPins="true">
                               <Patch Id="GVLklAuyWzLNkBU5z3rh7k" Name="Create" ManuallySortedPins="true" />
                               <Patch Id="Fj1HU24fHDkMdXlTHSzDDw" Name="Then" ManuallySortedPins="true" />
-                              <Node Bounds="1039,544,124,19" Id="C6pE7i5mINeNFGpaqQRFV7">
+                              <Node Bounds="359,489,124,19" Id="C6pE7i5mINeNFGpaqQRFV7">
                                 <p:NodeReference LastCategoryFullName="Stride.API.Core.Mathematics" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="OperationCallFlag" Name="CreateUnitBoundingBox" />
@@ -10004,10 +10004,10 @@
                                 <Pin Id="Eh3VFxgBc62LWlJPfHTB8s" Name="Output" Kind="OutputPin" />
                               </Node>
                             </Patch>
-                            <ControlPoint Id="MotlkcrUlK5Lfd1entC8WZ" Bounds="1041,587" Alignment="Bottom" />
-                            <ControlPoint Id="Ta7796E4wzqNXgAiyNjpgV" Bounds="1042,521" Alignment="Top" />
+                            <ControlPoint Id="MotlkcrUlK5Lfd1entC8WZ" Bounds="361,532" Alignment="Bottom" />
+                            <ControlPoint Id="Ta7796E4wzqNXgAiyNjpgV" Bounds="362,465" Alignment="Top" />
                           </Node>
-                          <Node Bounds="1027,475,25,19" Id="J3m5tStEP5ULE34ocX7FTW">
+                          <Node Bounds="347,420,25,19" Id="J3m5tStEP5ULE34ocX7FTW">
                             <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="=" />
@@ -10016,7 +10016,7 @@
                             <Pin Id="QzrPZnMJSTLNVhMxFVkIlP" Name="Input 2" Kind="InputPin" />
                             <Pin Id="NQGFFsMOmElQNWso6CdE76" Name="Result" Kind="OutputPin" />
                           </Node>
-                          <Node Bounds="1633,709,88,26" Id="G6xyQzKK9aaP4BN0pp4q2Q">
+                          <Node Bounds="953,654,88,26" Id="G6xyQzKK9aaP4BN0pp4q2Q">
                             <p:NodeReference LastCategoryFullName="Stride.API.Rendering.ParameterCollection" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="ClassType" Name="ParameterCollection" NeedsToBeDirectParent="true" />
@@ -10035,14 +10035,14 @@
                             <Pin Id="PdmXLGbwMBtN9bahm3tD9q" Name="Value" Kind="InputPin" />
                             <Pin Id="Hb8NrR8OJ8vQEWrosP3bAM" Name="Output" Kind="StateOutputPin" />
                           </Node>
-                          <Node Bounds="1674,616,116,19" Id="PCXPBad97pBMdhQFJBr5hr">
+                          <Node Bounds="994,561,116,19" Id="PCXPBad97pBMdhQFJBr5hr">
                             <p:NodeReference LastCategoryFullName="VL.Stride.Rendering.VLEffectParameters" LastSymbolSource="VL.Stride.Runtime.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="EnableExtensionName" />
                             </p:NodeReference>
                             <Pin Id="QdySBLeTFlPO60THD6tF99" Name="Enable Extension Name" Kind="OutputPin" />
                           </Node>
-                          <Node Bounds="1632,812,88,26" Id="Q8c08dxY8XRPUIIiwY4QoX">
+                          <Node Bounds="952,757,88,26" Id="Q8c08dxY8XRPUIIiwY4QoX">
                             <p:NodeReference LastCategoryFullName="Stride.API.Rendering.ParameterCollection" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="ClassType" Name="ParameterCollection" NeedsToBeDirectParent="true" />
@@ -10061,7 +10061,7 @@
                             <Pin Id="Kr5PDvMbr26Obin0xam5xH" Name="Value" Kind="InputPin" />
                             <Pin Id="Hh3enWx4FH1LXK8BCfp2MP" Name="Output" Kind="StateOutputPin" />
                           </Node>
-                          <Node Bounds="1674,763,123,19" Id="DMpysqpwYZOMnKqyMfii75">
+                          <Node Bounds="994,708,123,19" Id="DMpysqpwYZOMnKqyMfii75">
                             <p:NodeReference LastCategoryFullName="VL.Stride.Rendering.VLEffectParameters" LastSymbolSource="VL.Stride.Runtime.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <AssemblyReference ID="VL.Stride.Runtime.dll" />
@@ -10072,7 +10072,7 @@
                             </p:NodeReference>
                             <Pin Id="DsGz7rpftZQOZMJYAAtP1w" Name="Material Extension Name" Kind="OutputPin" />
                           </Node>
-                          <Node Bounds="1716,655,104,19" Id="BL1kxb25U7zOuIbr39D3Ol">
+                          <Node Bounds="1036,600,104,19" Id="BL1kxb25U7zOuIbr39D3Ol">
                             <p:NodeReference LastCategoryFullName="Primitive.String" LastSymbolSource="CoreLibBasics.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="IsNullOrWhiteSpace" />
@@ -10080,7 +10080,7 @@
                             <Pin Id="UOo02oeqQpDQchNOvG78B5" Name="Input" Kind="StateInputPin" />
                             <Pin Id="Kj93uHFeD82Mq6g4LlU1ra" Name="Result" Kind="OutputPin" />
                           </Node>
-                          <Node Bounds="1716,682,37,19" Id="EzK5UWvvbn0MSV3YKfbVxK">
+                          <Node Bounds="1036,627,37,19" Id="EzK5UWvvbn0MSV3YKfbVxK">
                             <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="NOT" />
@@ -10088,7 +10088,7 @@
                             <Pin Id="QQyeLqISpl9OFjxmQGt31I" Name="Input" Kind="StateInputPin" />
                             <Pin Id="OchLE8XAld6N1bYRGQ1RVV" Name="Output" Kind="StateOutputPin" />
                           </Node>
-                          <Node Bounds="1570,506,67,26" Id="CioXUr9Elo5P7P1Ff7M3sb">
+                          <Node Bounds="890,451,67,26" Id="CioXUr9Elo5P7P1Ff7M3sb">
                             <p:NodeReference LastCategoryFullName="Stride.API.Rendering.Mesh" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="Parameters" />
@@ -10098,14 +10098,14 @@
                             <Pin Id="NVntI2PNJDeM2LcMe0icGz" Name="Output" Kind="StateOutputPin" />
                             <Pin Id="RQ2famn2hgANf1IoYPttxV" Name="Parameters" Kind="OutputPin" />
                           </Node>
-                          <Node Bounds="1922,544,121,19" Id="RVZW0bLSc6PLLQHIhgExil">
+                          <Node Bounds="1242,489,121,19" Id="RVZW0bLSc6PLLQHIhgExil">
                             <p:NodeReference LastCategoryFullName="VL.Stride.Rendering.VLEffectParameters" LastSymbolSource="VL.Stride.Runtime.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="EnableExtensionShader" />
                             </p:NodeReference>
                             <Pin Id="J3kAEDzAJBbOiIS9240CaT" Name="Enable Extension Shader" Kind="OutputPin" />
                           </Node>
-                          <Node Bounds="1965,573,65,19" Id="FgOXHfdQXudP6NtL88pVre">
+                          <Node Bounds="1285,518,65,19" Id="FgOXHfdQXudP6NtL88pVre">
                             <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="IsAssigned" />
@@ -10114,7 +10114,7 @@
                             <Pin Id="IC3kvM7PXOJL28hSCqLIn8" Name="Result" Kind="OutputPin" />
                             <Pin Id="MkEMoVqrD8SPnQUGniLZDF" Name="Not Assigned" Kind="OutputPin" />
                           </Node>
-                          <Node Bounds="1924,680,128,19" Id="SUXpMlvqtQxM3EvZoeSqOS">
+                          <Node Bounds="1244,625,128,19" Id="SUXpMlvqtQxM3EvZoeSqOS">
                             <p:NodeReference LastCategoryFullName="VL.Stride.Rendering.VLEffectParameters" LastSymbolSource="VL.Stride.Runtime.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <AssemblyReference ID="VL.Stride.Runtime.dll" />
@@ -10125,7 +10125,7 @@
                             </p:NodeReference>
                             <Pin Id="BGF4SMgyoyVN8wirASL8D5" Name="Material Extension Shader" Kind="OutputPin" />
                           </Node>
-                          <Node Bounds="1883,735,88,26" Id="U0QqlvTIWTGQABDdOC4QMi">
+                          <Node Bounds="1203,680,88,26" Id="U0QqlvTIWTGQABDdOC4QMi">
                             <p:NodeReference LastCategoryFullName="Stride.API.Rendering.ParameterCollection" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="ClassType" Name="ParameterCollection" NeedsToBeDirectParent="true" />
@@ -10144,7 +10144,7 @@
                             <Pin Id="JRj2ejRnoPOOs0roS8r5hU" Name="Value" Kind="InputPin" />
                             <Pin Id="LisPbJtLb2oOCmRpVtm0d4" Name="Output" Kind="StateOutputPin" />
                           </Node>
-                          <Node Bounds="1882,621,88,26" Id="TM4X6kppGm6N9kS8YwB49d">
+                          <Node Bounds="1202,566,88,26" Id="TM4X6kppGm6N9kS8YwB49d">
                             <p:NodeReference LastCategoryFullName="Stride.API.Rendering.ParameterCollection" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="ClassType" Name="ParameterCollection" NeedsToBeDirectParent="true" />
@@ -10165,7 +10165,7 @@
                           </Node>
                         </Patch>
                       </Node>
-                      <Node Bounds="925,316,336,26" Id="Hc9OwacExyAMgg3bhqSwMS">
+                      <Node Bounds="245,261,336,26" Id="Hc9OwacExyAMgg3bhqSwMS">
                         <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (5 Items)" LastSymbolSource="CoreLibBasics.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Create" />
@@ -10178,7 +10178,7 @@
                         <Pin Id="DLCsmYaToIyOwDqiY4s6HC" Name="Item 5" Kind="InputPin" />
                         <Pin Id="IfSOl5E6Iz8M0v7KB6NSA7" Name="Output" Kind="StateOutputPin" />
                       </Node>
-                      <Node Bounds="1348,304,86,19" Id="Ka1UHTfTmxfOm8obeGmp4q">
+                      <Node Bounds="668,249,86,19" Id="Ka1UHTfTmxfOm8obeGmp4q">
                         <p:NodeReference LastCategoryFullName="Stride.Utils" LastSymbolSource="VL.Stride.Graphics.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="GraphicsDevice" />
@@ -10190,9 +10190,9 @@
                       </Node>
                     </Patch>
                   </Node>
-                  <ControlPoint Id="CgP0stRK7NcP6InTYXFfFu" Bounds="1095,222" />
-                  <ControlPoint Id="NkMHITU2QiWOqmNyGRwk5e" Bounds="1219,223" />
-                  <ControlPoint Id="J51WparQQ9QNrIz2lOSplB" Bounds="1367,222" />
+                  <ControlPoint Id="CgP0stRK7NcP6InTYXFfFu" Bounds="415,167" />
+                  <ControlPoint Id="NkMHITU2QiWOqmNyGRwk5e" Bounds="539,168" />
+                  <ControlPoint Id="J51WparQQ9QNrIz2lOSplB" Bounds="687,167" />
                 </Canvas>
                 <Patch Id="AXDb9F1CCksM5bUdoakhLs" Name="Create" />
                 <Patch Id="MGFR0jQA07KMTznDnsyXGh" Name="Update">
@@ -11388,7 +11388,7 @@
                         <Pin Id="GqQG0f07Oe9NFBfR0SGelp" Name="Result" Kind="OutputPin" />
                         <Pin Id="QWnrCneYbbUNj5dkbP8rTN" Name="Not Assigned" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="335,332,96,118" Id="IJC0PtlX74PNChHdhfmbbY">
+                      <Node Bounds="333,332,126,120" Id="IJC0PtlX74PNChHdhfmbbY">
                         <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
                           <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                           <Choice Kind="ApplicationStatefulRegion" Name="If" />
@@ -11408,7 +11408,7 @@
                             <Pin Id="HR4uQCio15IPordCFV5Z7X" Name="Mesh" Kind="InputPin" />
                             <Pin Id="R0OBNCe8dupOAeuDuIDrWs" Name="Output" Kind="StateOutputPin" />
                           </Node>
-                          <Node Bounds="381,404,38,26" Id="LmddTZDc3YyQFdvikiAdqp">
+                          <Node Bounds="401,402,38,26" Id="LmddTZDc3YyQFdvikiAdqp">
                             <p:NodeReference LastCategoryFullName="Stride.API.Rendering.Model" LastSymbolSource="VL.Stride.Runtime.CSharpImport.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="Add" />
@@ -11418,6 +11418,14 @@
                             <Pin Id="QTkNIzYkVKGOGKGvWd1EpS" Name="Input" Kind="StateInputPin" />
                             <Pin Id="JUibtGBHDaQPfmq65qrzn5" Name="Mesh" Kind="InputPin" />
                             <Pin Id="EYRfOBHj5E2LtUqInwvZnM" Name="Output" Kind="StateOutputPin" />
+                          </Node>
+                          <Node Bounds="345,406,102,26" Id="NGxEU4LuiOVPTsdYpflqAb">
+                            <p:NodeReference LastCategoryFullName="VL.Stride.Rendering.MeshExtensions" LastSymbolSource="VL.Stride.Runtime.dll">
+                              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                              <Choice Kind="OperationCallFlag" Name="ReplaceParameters" />
+                            </p:NodeReference>
+                            <Pin Id="Dyjlm82d1rVNUNGatT1H8f" Name="Input" Kind="StateInputPin" />
+                            <Pin Id="RBq8dko7FwsQBTYNmKitwp" Name="Output" Kind="OutputPin" />
                           </Node>
                         </Patch>
                       </Node>
@@ -11564,6 +11572,7 @@
             <Link Id="C9wJ8DiD0qgNCMta9CtfYV" Ids="NQqtobLCDWjMzHxyOYKAxN,Dvi7FtptD9wOw63Bvm3RRj" />
             <Link Id="KCcczDmgURaN9vxljtvhMF" Ids="FkHlGd3jNy5Ovs1MD38JKG,JJKofBkU0FCPujt0WjC9i3" />
             <Link Id="DQw0FIkur37OJYqbg3yeWy" Ids="H1ehMBy9WR2Pi1j6XJuQJe,U90yILsd11nMHO8zl76mLM" />
+            <Link Id="DyjksWIjgliMNR4KydeWHD" Ids="R0OBNCe8dupOAeuDuIDrWs,Dyjlm82d1rVNUNGatT1H8f" />
           </Patch>
         </Node>
         <!--

--- a/packages/VL.Stride.Runtime/VL.Stride.Rendering.vl
+++ b/packages/VL.Stride.Runtime/VL.Stride.Rendering.vl
@@ -9826,7 +9826,7 @@
                     <Patch Id="HkUgkwUOt0wMQl7L0Lrxa7" ManuallySortedPins="true">
                       <Patch Id="Ey2ESMqS1J3O8nUHzRMOC5" Name="Create" ManuallySortedPins="true" />
                       <Patch Id="T3neN6yUpVVO3ynkdNy9yO" Name="Then" ManuallySortedPins="true" />
-                      <Node Bounds="262,329,1122,508" Id="NkPVASx76QNP43IG4zUg5S">
+                      <Node Bounds="262,329,1146,508" Id="NkPVASx76QNP43IG4zUg5S">
                         <p:NodeReference LastCategoryFullName="System.Resources" LastSymbolSource="CoreLibBasics.vl">
                           <Choice Kind="OperationCallFlag" Name="NewPooled (PerApp)" />
                           <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
@@ -9888,7 +9888,7 @@
                             <Pin Id="NIRezSDL6hIQFpb27Pr0iV" Name="Vertex Offset" Kind="InputPin" />
                             <Pin Id="BaVAXzR38CfNj4EvTXSQdN" Name="Output" Kind="StateOutputPin" />
                           </Node>
-                          <Node Bounds="338,586,53,26" Id="BxJDwi0L5iANOPbTPSMN5L">
+                          <Node Bounds="350,592,53,26" Id="BxJDwi0L5iANOPbTPSMN5L">
                             <p:NodeReference LastCategoryFullName="Stride.Rendering.MeshDraw" LastSymbolSource="Stride.Rendering.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="AssemblyCategory" Name="MeshDraw" />
@@ -9924,15 +9924,7 @@
                             <Pin Id="PTdqXOpSFE3QBqUgfoF7Px" Name="Value" Kind="InputPin" />
                             <Pin Id="KC0QzzDKAAHOihh8WBaRXR" Name="Output" Kind="StateOutputPin" />
                           </Node>
-                          <Node Bounds="689,675,67,19" Id="DBse2yFZw87LFLxH3RA8k3">
-                            <p:NodeReference LastCategoryFullName="Stride.API.Graphics.VertexDeclaration" LastSymbolSource="VL.Stride.Runtime.CSharpImport.vl">
-                              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                              <CategoryReference Kind="ClassType" Name="VertexDeclaration" />
-                              <Choice Kind="OperationCallFlag" Name="CreatePos4" />
-                            </p:NodeReference>
-                            <Pin Id="VoJ5HlGEssUPCW7ofB8Hu1" Name="Output" Kind="StateOutputPin" />
-                          </Node>
-                          <Node Bounds="668,644,45,19" Id="Gq4EjrG6SMnL4DaXpD9EJR">
+                          <Node Bounds="668,651,45,19" Id="Gq4EjrG6SMnL4DaXpD9EJR">
                             <p:NodeReference LastCategoryFullName="Stride.Graphics.Buffer.Vertex" LastSymbolSource="Stride.Graphics.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="AssemblyCategory" Name="Vertex" />
@@ -9951,21 +9943,6 @@
                             <Pin Id="T9aVMJcf6NOLzds9qMfEN6" Name="Usage" Kind="InputPin" />
                             <Pin Id="T3F6JBpBi18OfrnXvWJ0EA" Name="Result" Kind="OutputPin" />
                           </Node>
-                          <Node Bounds="688,608,64,26" Id="AeCIlGiK8pZO6A4QnntdYA">
-                            <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableArray" LastSymbolSource="VL.Collections.vl">
-                              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                              <CategoryReference Kind="ArrayType" Name="MutableArray" />
-                              <Choice Kind="OperationCallFlag" Name="ToArray" />
-                            </p:NodeReference>
-                            <Pin Id="RRyJEOPPTLbPehUlDk9KBg" Name="Input" Kind="StateInputPin" />
-                            <Pin Id="LCwzl6u21oOOd8a5KJG0nN" Name="Result" Kind="OutputPin" />
-                          </Node>
-                          <Pad Id="IPkF3ShcxNxMrZDzQMvPXX" Comment="Input" Bounds="690,542,35,57" ShowValueBox="true" isIOBox="true" Value="0, 0, 0, 1">
-                            <p:TypeAnnotation>
-                              <Choice Kind="TypeFlag" Name="Vector4" />
-                              <FullNameCategoryReference ID="3D" />
-                            </p:TypeAnnotation>
-                          </Pad>
                           <Node Bounds="349,665,81,26" Id="Ahuf2KmQghmPLT6og8ziYr">
                             <p:NodeReference LastCategoryFullName="Stride.API.Rendering.MeshDraw" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -10038,9 +10015,9 @@
                           <Node Bounds="994,561,116,19" Id="PCXPBad97pBMdhQFJBr5hr">
                             <p:NodeReference LastCategoryFullName="VL.Stride.Rendering.VLEffectParameters" LastSymbolSource="VL.Stride.Runtime.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                              <Choice Kind="OperationCallFlag" Name="EnableExtensionName" />
+                              <Choice Kind="OperationCallFlag" Name="EnableExtensionNameMesh" />
                             </p:NodeReference>
-                            <Pin Id="QdySBLeTFlPO60THD6tF99" Name="Enable Extension Name" Kind="OutputPin" />
+                            <Pin Id="GoPduCehHOvMl1gjM7po3v" Name="Enable Extension Name Mesh" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="952,757,88,26" Id="Q8c08dxY8XRPUIIiwY4QoX">
                             <p:NodeReference LastCategoryFullName="Stride.API.Rendering.ParameterCollection" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl">
@@ -10068,9 +10045,9 @@
                               <CategoryReference Kind="AssemblyCategory" Name="VL" />
                               <CategoryReference Kind="AssemblyCategory" Name="Stride" />
                               <CategoryReference Kind="AssemblyCategory" Name="Rendering" />
-                              <Choice Kind="OperationCallFlag" Name="MaterialExtensionName" />
+                              <Choice Kind="OperationCallFlag" Name="MaterialExtensionNameMesh" />
                             </p:NodeReference>
-                            <Pin Id="DsGz7rpftZQOZMJYAAtP1w" Name="Material Extension Name" Kind="OutputPin" />
+                            <Pin Id="AVvyB0bAudbP06CjsCKaO3" Name="Material Extension Name Mesh" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="1036,600,104,19" Id="BL1kxb25U7zOuIbr39D3Ol">
                             <p:NodeReference LastCategoryFullName="Primitive.String" LastSymbolSource="CoreLibBasics.vl">
@@ -10101,9 +10078,9 @@
                           <Node Bounds="1242,489,121,19" Id="RVZW0bLSc6PLLQHIhgExil">
                             <p:NodeReference LastCategoryFullName="VL.Stride.Rendering.VLEffectParameters" LastSymbolSource="VL.Stride.Runtime.dll">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                              <Choice Kind="OperationCallFlag" Name="EnableExtensionShader" />
+                              <Choice Kind="OperationCallFlag" Name="EnableExtensionShaderMesh" />
                             </p:NodeReference>
-                            <Pin Id="J3kAEDzAJBbOiIS9240CaT" Name="Enable Extension Shader" Kind="OutputPin" />
+                            <Pin Id="CxtMTmwc7ynQLQiIKSFjbB" Name="Enable Extension Shader Mesh" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="1285,518,65,19" Id="FgOXHfdQXudP6NtL88pVre">
                             <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl">
@@ -10121,9 +10098,9 @@
                               <CategoryReference Kind="AssemblyCategory" Name="VL" />
                               <CategoryReference Kind="AssemblyCategory" Name="Stride" />
                               <CategoryReference Kind="AssemblyCategory" Name="Rendering" />
-                              <Choice Kind="OperationCallFlag" Name="MaterialExtensionShader" />
+                              <Choice Kind="OperationCallFlag" Name="MaterialExtensionShaderMesh" />
                             </p:NodeReference>
-                            <Pin Id="BGF4SMgyoyVN8wirASL8D5" Name="Material Extension Shader" Kind="OutputPin" />
+                            <Pin Id="GXMuoAanVjMLEbg51yqvW6" Name="Material Extension Shader Mesh" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="1203,680,88,26" Id="U0QqlvTIWTGQABDdOC4QMi">
                             <p:NodeReference LastCategoryFullName="Stride.API.Rendering.ParameterCollection" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl">
@@ -10163,6 +10140,24 @@
                             <Pin Id="MRZNgbY4DaXND4MiiVIHhS" Name="Value" Kind="InputPin" />
                             <Pin Id="QiCDAJIYsnDMNlweO3uH82" Name="Output" Kind="StateOutputPin" />
                           </Node>
+                          <Node Bounds="689,683,121,19" Id="A6jwdXiJ3qHOaCvy3jMo4J">
+                            <p:NodeReference LastCategoryFullName="Stride.API.Graphics.VertexDeclaration" LastSymbolSource="VL.Stride.Runtime.TypeForwards.vl">
+                              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                              <CategoryReference Kind="ClassType" Name="VertexDeclaration" />
+                              <Choice Kind="OperationCallFlag" Name="CreatePos3Norm3Tex2" />
+                            </p:NodeReference>
+                            <Pin Id="Vd1PLy6flMlLZl8yviZTXT" Name="Output" Kind="StateOutputPin" />
+                          </Node>
+                          <Pad Id="VMd2aNw5CNCOjenVlBfUZk" Comment="" Bounds="728,524,62,99" ShowValueBox="true" isIOBox="true" Value="0, 0, 0, 0, 1, 0, 0, 0">
+                            <p:TypeAnnotation LastCategoryFullName="Collections.Mutable" LastSymbolSource="VL.Collections.vl">
+                              <Choice Kind="TypeFlag" Name="MutableArray" />
+                              <p:TypeArguments>
+                                <TypeReference LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                                  <Choice Kind="TypeFlag" Name="Float32" />
+                                </TypeReference>
+                              </p:TypeArguments>
+                            </p:TypeAnnotation>
+                          </Pad>
                         </Patch>
                       </Node>
                       <Node Bounds="245,261,336,26" Id="Hc9OwacExyAMgg3bhqSwMS">
@@ -10208,8 +10203,8 @@
                     </p:TypeAnnotation>
                   </Pin>
                   <Pin Id="MKEFFX2ENtUNcCveJIp0RU" Name="Bounding Box" Kind="InputPin" Bounds="1100,256" Summary="Set a bounding box that roughly reflects the volume of what the shader outputs. It gets transformed by the world matrix of the entity. Default is a unit bounding box." />
-                  <Pin Id="QihdylejClnQJcX8J7RfW7" Name="Material Extension Name" Kind="InputPin" Bounds="613,54" Summary="Can be used to load a specific material override shader by name when this mesh is rendered." />
-                  <Pin Id="Bzwu8HPWyyIMeKIbQaUhr8" Name="Material Extension Shader" Kind="InputPin" Bounds="1376,225" Summary="Can be used to set a material override shader when this mesh is rendered." />
+                  <Pin Id="QihdylejClnQJcX8J7RfW7" Name="Material Extension Name" Kind="InputPin" Bounds="613,54" Visibility="Optional" Summary="Can be used to load a specific material override shader by name when this mesh is rendered." />
+                  <Pin Id="Bzwu8HPWyyIMeKIbQaUhr8" Name="Material Extension Shader" Kind="InputPin" Bounds="1376,225" Visibility="Optional" Summary="Can be used to set a material override shader when this mesh is rendered." />
                 </Patch>
                 <ProcessDefinition Id="H2flX5MLcuzNAtMsZtR1iE">
                   <Fragment Id="EgkLotRo10mMt3PbjA3NsG" Patch="AXDb9F1CCksM5bUdoakhLs" Enabled="true" />
@@ -10232,10 +10227,7 @@
                 <Link Id="Mw9wKOMqZTTNo8AsAfN8Nk" Ids="BaVAXzR38CfNj4EvTXSQdN,JjWPtOftSe2NYRCF2vaLVp" />
                 <Link Id="S6DMJLUVL8VPJ4rerJu3HD" Ids="BNeR9cuvdEyNAAHmKbaOz8,LyuWvuutq6gLEH1nRouIgG" />
                 <Link Id="At0OpZ0s2i1L7DCA5mhSFO" Ids="BNeR9cuvdEyNAAHmKbaOz8,MXvipX5sp6HO7afK1WNkeo" />
-                <Link Id="C4C6FjWkBhfLzJjchoMhsP" Ids="VoJ5HlGEssUPCW7ofB8Hu1,OAw64PvJZyFN1lFQ6HHLWp" />
-                <Link Id="MTZkjPDon5JM9F6QmPtu18" Ids="LCwzl6u21oOOd8a5KJG0nN,CJycUJiCZQXMM4AfwdHiCc" />
                 <Link Id="OkhPT46NM8bQR6GcGH0C6y" Ids="T3F6JBpBi18OfrnXvWJ0EA,FSoVtdF6OWcM3MhKb8vxsQ" />
-                <Link Id="LKTvOQsfvX3MiIjtmepQFW" Ids="IPkF3ShcxNxMrZDzQMvPXX,RRyJEOPPTLbPehUlDk9KBg" />
                 <Link Id="AQJpwrrTizoOUQdQUvtEFg" Ids="BGU4sn45EvAOWrwTYQONt9,LT5V9TqbxaWNzA5HG0msbW" />
                 <Link Id="HIv7NIvqoFLP64wDXZmA2k" Ids="UOFMLcIyQYMMzSVVlSBFxO,LTcO0Pi6r2ROTNjUHzUf3E" />
                 <Link Id="G2XO70AcSGuOWi51PSlu8f" Ids="JNfn6oGBaCENhme2HvdkDS,E6srZgJ8kBEQJ6k7DAukXh" />
@@ -10258,8 +10250,6 @@
                 <Link Id="CnES9T9VSUiMig37zZ1evS" Ids="NkMHITU2QiWOqmNyGRwk5e,Ixu5KFxVDvTPGHGLlREPCA" />
                 <Link Id="PiJeEQQBuKvQX08CZ2T9vF" Ids="Ixu5KFxVDvTPGHGLlREPCA,JGgb8mn9LHcLzpK00dhJLs" />
                 <Link Id="UhfzbKtsdFmMXZKmnoCgSA" Ids="Hb8NrR8OJ8vQEWrosP3bAM,D9U4oNMdZjtPCteYD1Nxdd" />
-                <Link Id="NQWz6vY3MuHQNGaBiOAROL" Ids="DsGz7rpftZQOZMJYAAtP1w,AkCp0HzOb3jNsMAptQx5qq" />
-                <Link Id="EHPdWE68JL1NguU3JxwJdC" Ids="QdySBLeTFlPO60THD6tF99,MUJgC1iqpg2LbFJ4Akbuy3" />
                 <Link Id="BKhEM9cPp1hO3XcBueYA7b" Ids="Kj93uHFeD82Mq6g4LlU1ra,QQyeLqISpl9OFjxmQGt31I" />
                 <Link Id="T0ZODntWLU9OMjw8uboZdI" Ids="OchLE8XAld6N1bYRGQ1RVV,PdmXLGbwMBtN9bahm3tD9q" />
                 <Link Id="UOpz4FibGISLLqwSGBUR0k" Ids="PBfK0yoAmSQLjsrza2Xiaz,QwEEUzl6D6WOH0f2dVBew2" />
@@ -10269,13 +10259,17 @@
                 <Link Id="IqBJr8hO0t5MziB02bSW2V" Ids="MpypzXKJb6SPsz5yWjaQ0N,DLCsmYaToIyOwDqiY4s6HC" />
                 <Link Id="VJXQjIE6RcQPfxVAth8Ah5" Ids="J51WparQQ9QNrIz2lOSplB,MpypzXKJb6SPsz5yWjaQ0N" />
                 <Link Id="UgL0JMDBPhoQdSJToTzrCJ" Ids="Bzwu8HPWyyIMeKIbQaUhr8,J51WparQQ9QNrIz2lOSplB" IsHidden="true" />
-                <Link Id="IFcky4FK3tNLeW6Gualddq" Ids="BGF4SMgyoyVN8wirASL8D5,AC5WEQrhh2ENXrDMH7desg" />
                 <Link Id="Gb0G7aJS9YAOELPurVQcJ0" Ids="Aehyqhx9gynNGiLmKyVDD1,JRj2ejRnoPOOs0roS8r5hU" />
                 <Link Id="HBE6JAC2ex8NlOKzI5CylN" Ids="IC3kvM7PXOJL28hSCqLIn8,MRZNgbY4DaXND4MiiVIHhS" />
-                <Link Id="L0jQxPNVYmuPrpK5MUCUEy" Ids="J3kAEDzAJBbOiIS9240CaT,EWLaURpVs5EO9fXyObJBmd" />
                 <Link Id="CKkU5QjMT9lPZWBbjQsxVR" Ids="QiCDAJIYsnDMNlweO3uH82,TukbtlR1yg5OshTVmtNjHt" />
                 <Link Id="NYtDj6zcRHHLclF5amksbV" Ids="RQ2famn2hgANf1IoYPttxV,HVFnUZOvKWGOMwbSWYMEvs" />
                 <Link Id="PMQnuNOmGAjMBgWeuiGGZK" Ids="Aehyqhx9gynNGiLmKyVDD1,OduynRNZNq7Lw4xdmyZFFm" />
+                <Link Id="AB31pOYOhC8NPp2ZJryMdL" Ids="AVvyB0bAudbP06CjsCKaO3,AkCp0HzOb3jNsMAptQx5qq" />
+                <Link Id="Os19C3n8SaDOCllGaFigny" Ids="GoPduCehHOvMl1gjM7po3v,MUJgC1iqpg2LbFJ4Akbuy3" />
+                <Link Id="A6KEQW5byCTMwByl9hWIuM" Ids="CxtMTmwc7ynQLQiIKSFjbB,EWLaURpVs5EO9fXyObJBmd" />
+                <Link Id="C5zYJ6ZJnWXLAP36KnbYAN" Ids="GXMuoAanVjMLEbg51yqvW6,AC5WEQrhh2ENXrDMH7desg" />
+                <Link Id="BhZxotxCcYmO1h1gtmgAVQ" Ids="Vd1PLy6flMlLZl8yviZTXT,OAw64PvJZyFN1lFQ6HHLWp" />
+                <Link Id="LPJC8RiyxpkNnrczgxwmhq" Ids="VMd2aNw5CNCOjenVlBfUZk,CJycUJiCZQXMM4AfwdHiCc" />
               </Patch>
             </Node>
           </Canvas>

--- a/packages/VL.Stride.Runtime/help/Rendering/Example GPU Particle System with PBR.vl
+++ b/packages/VL.Stride.Runtime/help/Rendering/Example GPU Particle System with PBR.vl
@@ -685,10 +685,10 @@
         <Patch Id="TNXyJkNaFm8LsFl52SuweE">
           <Canvas Id="LiFafMZE7fxM02SmnaR90y" CanvasType="Group">
             <ControlPoint Id="OySo4puW8uhLZlTetVJw8i" Bounds="702,785" />
-            <ControlPoint Id="T8HWV3G7HJVLeLtbpxvYVi" Bounds="451,760" />
+            <ControlPoint Id="T8HWV3G7HJVLeLtbpxvYVi" Bounds="393,768" />
             <ControlPoint Id="BMonosI7mIQL5iDL7qNnjW" Bounds="156,873" />
             <ControlPoint Id="QfYuwGUnBlBPtxW6YsUYUA" Bounds="683,743" />
-            <Node Bounds="425,1138,165,19" Id="OOKIYjpKbILOfBMYmg8R5g">
+            <Node Bounds="357,1123,165,19" Id="OOKIYjpKbILOfBMYmg8R5g">
               <p:NodeReference LastCategoryFullName="Stride.Models" LastSymbolSource="VL.Stride.Engine.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="MeshEntity" />
@@ -707,17 +707,17 @@
               <Pin Id="D6E9GHJJAUEPpO7Na9Zl1Y" Name="Enabled" Kind="InputPin" />
               <Pin Id="KAnSujhgD1wPiLnXriVK1F" Name="Entity" Kind="OutputPin" />
             </Node>
-            <Pad Id="AF0cvKe07jePmfoKZpjtvQ" Comment="Metalness" Bounds="471,787,35,15" ShowValueBox="true" isIOBox="true" Value="0.72">
+            <Pad Id="AF0cvKe07jePmfoKZpjtvQ" Comment="Metalness" Bounds="413,795,35,15" ShowValueBox="true" isIOBox="true" Value="0.72">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pad>
-            <Pad Id="LSaRtghPTjtLxuMLOhjvO4" Comment="Roughness" Bounds="491,816,36,15" ShowValueBox="true" isIOBox="true" Value="0.7">
+            <Pad Id="LSaRtghPTjtLxuMLOhjvO4" Comment="Roughness" Bounds="433,824,36,15" ShowValueBox="true" isIOBox="true" Value="0.7">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pad>
-            <Node Bounds="449,838,85,19" Id="AdDUxIGmXjHPRqn4TNKT5Q">
+            <Node Bounds="391,846,85,19" Id="AdDUxIGmXjHPRqn4TNKT5Q">
               <p:NodeReference LastCategoryFullName="Stride.Materials" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="PBRMaterial" />
@@ -729,7 +729,7 @@
               <Pin Id="QlESHeLYkX3NcPZROPceCZ" Name="Cull Mode" Kind="InputPin" />
               <Pin Id="SIRNI7PSspkLAFJ4F0Nzgm" Name="Output" Kind="OutputPin" />
             </Node>
-            <Node Bounds="640,841,105,19" Id="GaEN7sKUX6cO6Un9nfuerf">
+            <Node Bounds="591,864,105,19" Id="GaEN7sKUX6cO6Un9nfuerf">
               <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastSymbolSource="VL.Stride.Rendering.EffectShaderNodes">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessNode" Name="MyParticleProvider" />
@@ -742,9 +742,9 @@
               <Pin Id="KFU2c3HkDkRQFtWlRFYMcE" Name="P Norm" Kind="InputPin" />
               <Pin Id="EFfcoEBeJa6ME1SkP42T4t" Name="Output" Kind="OutputPin" />
             </Node>
-            <ControlPoint Id="AHC3Ei8VQbiPO8izVVE2Yu" Bounds="428,1208" />
+            <ControlPoint Id="AHC3Ei8VQbiPO8izVVE2Yu" Bounds="358,1183" />
             <ControlPoint Id="Rf9co0qPTV4Phyn12aoK6q" Bounds="722,817" />
-            <Node Bounds="230,949,85,19" Id="IbFdLXOYlhvLvujOS0OI2V">
+            <Node Bounds="230,967,85,19" Id="IbFdLXOYlhvLvujOS0OI2V">
               <p:NodeReference LastCategoryFullName="Stride.Models.Meshes" LastSymbolSource="VL.Stride.Rendering.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="NullMesh" />
@@ -777,17 +777,18 @@
               </p:TypeAnnotation>
             </Pad>
             <Pad Id="EFbGpulzUPgMiOEcQq0fOK" Bounds="272,893" />
-            <Node Bounds="640,890,88,19" Id="C5Kiud6dRrDOzUGJrUOkFV">
+            <Node Bounds="440,937,88,19" Id="C5Kiud6dRrDOzUGJrUOkFV">
               <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastSymbolSource="VL.Stride.Rendering.EffectShaderNodes">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessNode" Name="SphereImpostor" />
               </p:NodeReference>
               <Pin Id="PFwk8VjSze5LiHXYDOKsjL" Name="Provider" Kind="InputPin" />
               <Pin Id="FkwkQpaX5KoO3wiy8nFoyv" Name="Shading Color 0" Kind="InputPin" />
+              <Pin Id="Tmtra6ouKaCL5ViIz66inV" Name="Scaling" Kind="InputPin" />
               <Pin Id="PHSwqpIyoR2OI2zfObUGvJ" Name="World" Kind="InputPin" />
               <Pin Id="AeBEXmDS50pMUnjFVosYeK" Name="Output" Kind="OutputPin" />
             </Node>
-            <Node Bounds="474,982,105,19" Id="MpcHgDOiRQyNMuFKuXTJRw">
+            <Node Bounds="414,1026,105,19" Id="MpcHgDOiRQyNMuFKuXTJRw">
               <p:NodeReference LastCategoryFullName="Stride.Materials" LastSymbolSource="VL.Stride.Rendering.Nodes">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="MaterialExtension" />
@@ -800,6 +801,15 @@
               <Pin Id="HDnvz8kd4ytL3yKfSwpUSi" Name="Cutoff" Kind="InputPin" />
               <Pin Id="OpBeV3cBNtPOeXz08hXgp5" Name="Output" Kind="OutputPin" />
             </Node>
+            <Pad Id="JucKjnP0EMaMlvbV9Rs9Gt" Comment="Cutoff" Bounds="557,964,35,35" ShowValueBox="true" isIOBox="true" Value="True">
+              <p:TypeAnnotation>
+                <Choice Kind="TypeFlag" Name="Boolean" />
+                <FullNameCategoryReference ID="Primitive" />
+              </p:TypeAnnotation>
+              <p:ValueBoxSettings>
+                <p:buttonmode p:Assembly="VL.UI.Forms" p:Type="VL.HDE.PatchEditor.Editors.ButtonModeEnum">Toggle</p:buttonmode>
+              </p:ValueBoxSettings>
+            </Pad>
           </Canvas>
           <ProcessDefinition Id="OV42zxvJSXrOcc7IF1pVEB">
             <Fragment Id="MBXzQIHc1eiPDYPqpy7Mee" Patch="CZFIDMWPYHJQbFewVCJQDo" Enabled="true" />
@@ -841,10 +851,11 @@
           <Link Id="N3VZ1rhMPg2QYoWruafctA" Ids="SIRNI7PSspkLAFJ4F0Nzgm,HBzU9zRz7EJPf2cgsR9qbQ" />
           <Link Id="UPndFQsSY92Ob6gWGvdsbC" Ids="OpBeV3cBNtPOeXz08hXgp5,NpDbnRkBJogP8nV8adtwMr" />
           <Link Id="GCB2BhExgYaOw6wb9ki3N7" Ids="AeBEXmDS50pMUnjFVosYeK,Kqg9uzWEz4GLT6xOQ9PwQy" />
-          <Link Id="I5qOHWMo8HkMiHiU6AMGNa" Ids="KAnSujhgD1wPiLnXriVK1F,AHC3Ei8VQbiPO8izVVE2Yu" />
           <Link Id="ObEvBbKRGkHOFauCxcHsQ1" Ids="T8HWV3G7HJVLeLtbpxvYVi,UdnmNGnHlIFOMEmXZcOwzm" />
           <Link Id="CGaiOlZZxxELSoeGhXPnBL" Ids="AF0cvKe07jePmfoKZpjtvQ,MBiode4s1cOMRZM5ZnPRSG" />
           <Link Id="TBwnFgi8MpsL84l2Y9kLfa" Ids="LSaRtghPTjtLxuMLOhjvO4,MWcUCDEKHyBL2UILeODshN" />
+          <Link Id="VikwEqtd4f4PoSa43zZghy" Ids="JucKjnP0EMaMlvbV9Rs9Gt,HDnvz8kd4ytL3yKfSwpUSi" />
+          <Link Id="QPIVW0iecAjNN6mXidRwqG" Ids="KAnSujhgD1wPiLnXriVK1F,AHC3Ei8VQbiPO8izVVE2Yu" />
         </Patch>
       </Node>
     </Canvas>
@@ -865,7 +876,7 @@
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SceneWindow" />
             </p:NodeReference>
-            <Pin Id="KB5Y8vreWQpLa79zg7iUUW" Name="Bounds" Kind="InputPin" DefaultValue="1165.6, 106.4, 648, 628">
+            <Pin Id="KB5Y8vreWQpLa79zg7iUUW" Name="Bounds" Kind="InputPin" DefaultValue="1028, 46.4, 648, 628">
               <p:TypeAnnotation LastCategoryFullName="2D" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Rectangle" />
               </p:TypeAnnotation>

--- a/packages/VL.Stride.Runtime/help/Rendering/Example GPU Particle System with PBR.vl
+++ b/packages/VL.Stride.Runtime/help/Rendering/Example GPU Particle System with PBR.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="IZNEdmWwsqTPmRYNCw6rdu" LanguageVersion="2021.4.0.314" Version="0.128">
-  <NugetDependency Id="UMjQW1rcsHzLbQEEvmlyux" Location="VL.CoreLib" Version="2021.4.0-0310-gbc7bb47474" />
+<Document xmlns:p="property" Id="IZNEdmWwsqTPmRYNCw6rdu" LanguageVersion="2021.4.0.365" Version="0.128">
+  <NugetDependency Id="UMjQW1rcsHzLbQEEvmlyux" Location="VL.CoreLib" Version="2021.4.0-0365-g698d9b47a2" />
   <Patch Id="E3ImUTd2YNGObBvmdtwudp">
     <Canvas Id="UxUkpQTPbkoLBVXkPUqMgv" DefaultCategory="Main" CanvasType="FullCategory">
       <!--
@@ -350,10 +350,10 @@
                 <Choice Kind="ProcessNode" Name="DrawPBR" />
               </p:NodeReference>
               <Pin Id="SCPhJrsoEiiO8KXcch0Eev" Name="Count" Kind="InputPin" />
+              <Pin Id="NaZSKq6ePIwP4hvKtZGKeK" Name="Color" Kind="InputPin" />
               <Pin Id="MiIJPMJqesuNjDzVPosxtt" Name="Particle Size" Kind="InputPin" />
               <Pin Id="S07aaiMTWKUQa8dU7ClGwG" Name="Particles Buffer" Kind="InputPin" />
               <Pin Id="B8kAGh4ElIEOaRQ6mmrdes" Name="Random Values" Kind="InputPin" />
-              <Pin Id="NaZSKq6ePIwP4hvKtZGKeK" Name="Color" Kind="InputPin" />
               <Pin Id="NMSKqU2FaCrNuVViGbIXHb" Name="Entity" Kind="OutputPin" />
             </Node>
             <Node Bounds="443,398,145,19" Id="CjjLTVliM2iPbUlsLXFX5O">
@@ -684,11 +684,11 @@
         </p:NodeReference>
         <Patch Id="TNXyJkNaFm8LsFl52SuweE">
           <Canvas Id="LiFafMZE7fxM02SmnaR90y" CanvasType="Group">
-            <ControlPoint Id="OySo4puW8uhLZlTetVJw8i" Bounds="458,424" />
-            <ControlPoint Id="T8HWV3G7HJVLeLtbpxvYVi" Bounds="579,449" />
-            <ControlPoint Id="BMonosI7mIQL5iDL7qNnjW" Bounds="64,555" />
-            <ControlPoint Id="QfYuwGUnBlBPtxW6YsUYUA" Bounds="434,396" />
-            <Node Bounds="448,716,165,19" Id="OOKIYjpKbILOfBMYmg8R5g">
+            <ControlPoint Id="OySo4puW8uhLZlTetVJw8i" Bounds="702,785" />
+            <ControlPoint Id="T8HWV3G7HJVLeLtbpxvYVi" Bounds="451,760" />
+            <ControlPoint Id="BMonosI7mIQL5iDL7qNnjW" Bounds="156,873" />
+            <ControlPoint Id="QfYuwGUnBlBPtxW6YsUYUA" Bounds="683,743" />
+            <Node Bounds="425,1138,165,19" Id="OOKIYjpKbILOfBMYmg8R5g">
               <p:NodeReference LastCategoryFullName="Stride.Models" LastSymbolSource="VL.Stride.Engine.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="MeshEntity" />
@@ -707,108 +707,44 @@
               <Pin Id="D6E9GHJJAUEPpO7Na9Zl1Y" Name="Enabled" Kind="InputPin" />
               <Pin Id="KAnSujhgD1wPiLnXriVK1F" Name="Entity" Kind="OutputPin" />
             </Node>
-            <Pad Id="KSi7j2G32eJMwinFyFD7Hn" Comment="Enabled" Bounds="629,672,35,35" ShowValueBox="true" isIOBox="true" Value="True">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="TypeFlag" Name="Boolean" />
-              </p:TypeAnnotation>
-              <p:ValueBoxSettings>
-                <p:buttonmode p:Assembly="VL.UI.Forms" p:Type="VL.HDE.PatchEditor.Editors.ButtonModeEnum">Toggle</p:buttonmode>
-              </p:ValueBoxSettings>
-            </Pad>
-            <Pad Id="AF0cvKe07jePmfoKZpjtvQ" Comment="Metalness" Bounds="410,315,35,15" ShowValueBox="true" isIOBox="true" Value="0.72">
+            <Pad Id="AF0cvKe07jePmfoKZpjtvQ" Comment="Metalness" Bounds="471,787,35,15" ShowValueBox="true" isIOBox="true" Value="0.72">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pad>
-            <Pad Id="LSaRtghPTjtLxuMLOhjvO4" Comment="Roughness" Bounds="678,498,35,15" ShowValueBox="true" isIOBox="true" Value="0.7">
+            <Pad Id="LSaRtghPTjtLxuMLOhjvO4" Comment="Roughness" Bounds="491,816,36,15" ShowValueBox="true" isIOBox="true" Value="0.7">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pad>
-            <Node Bounds="578,612,225,19" Id="AdDUxIGmXjHPRqn4TNKT5Q">
+            <Node Bounds="449,838,85,19" Id="AdDUxIGmXjHPRqn4TNKT5Q">
               <p:NodeReference LastCategoryFullName="Stride.Materials" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="PBRMaterial (Metallic)" />
+                <Choice Kind="ProcessAppFlag" Name="PBRMaterial" />
               </p:NodeReference>
-              <Pin Id="ODob4CbEUVXO8cmtLiMdtc" Name="Diffuse" Kind="InputPin" />
+              <Pin Id="UdnmNGnHlIFOMEmXZcOwzm" Name="Color" Kind="InputPin" />
               <Pin Id="MBiode4s1cOMRZM5ZnPRSG" Name="Metalness" Kind="InputPin" />
               <Pin Id="MWcUCDEKHyBL2UILeODshN" Name="Roughness" Kind="InputPin" />
-              <Pin Id="JHCedbHb4guOn5tsK5GKtf" Name="Normal" Kind="InputPin" />
-              <Pin Id="DG3gbV55WpYP7EPYZSL9gu" Name="Displacement" Kind="InputPin" />
-              <Pin Id="KpI5J2pfMnLLDQ2PXq0n0L" Name="Tessellation" Kind="InputPin" />
-              <Pin Id="QvO7V4kb7hxMtTJt7Ejy0H" Name="Occlusion" Kind="InputPin" />
-              <Pin Id="PhZ0PzwHKYnN7B39c504uM" Name="Subsurface Scattering" Kind="InputPin" />
-              <Pin Id="Mvkee2NKPLfLWA7lOyHZUL" Name="Emissive" Kind="InputPin" />
               <Pin Id="UwXXgu6T7nfNbVcjxYicOH" Name="Transparency" Kind="InputPin" />
-              <Pin Id="TosC2e96dQ0MSay3FTVPdH" Name="Layers" Kind="InputPin" />
               <Pin Id="QlESHeLYkX3NcPZROPceCZ" Name="Cull Mode" Kind="InputPin" />
               <Pin Id="SIRNI7PSspkLAFJ4F0Nzgm" Name="Output" Kind="OutputPin" />
             </Node>
-            <Node Bounds="578,517,49,19" Id="KH2K8K2ozjiLSPw3Bi8FnH">
-              <p:NodeReference LastCategoryFullName="Stride.Materials.Inputs" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="ColorIn" />
-                <CategoryReference Kind="Category" Name="Inputs" NeedsToBeDirectParent="true" />
-              </p:NodeReference>
-              <Pin Id="EsWw5kSGiAQMoPCN5v3Av0" Name="Value" Kind="InputPin" />
-              <Pin Id="TNJT8G3259kMRkUJY3yFAR" Name="Premultiply Alpha" Kind="InputPin" />
-              <Pin Id="HEt5ZuIifJoPjet0sCKAnu" Name="Output" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="676,531,25,19" Id="JvoFK8NRAWwMh1N4BkZ4XB">
-              <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="In" />
-              </p:NodeReference>
-              <Pin Id="H9ery95rnInPYtxIoqnQKr" Name="Value" Kind="InputPin" />
-              <Pin Id="Vqf9wuJmZoSLmOTeEr6NDc" Name="Output" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="758,558,54,19" Id="FEQdmsPifWeOkFdIGfp37A">
-              <p:NodeReference LastCategoryFullName="Stride.Materials.MiscAttributes.Transparency" LastSymbolSource="VL.Stride.Rendering.Nodes">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <CategoryReference Kind="Category" Name="Transparency" />
-                <Choice Kind="ProcessNode" Name="Cutoff" />
-              </p:NodeReference>
-              <Pin Id="LIoPCgQ5WoAPJLy9ozEgV4" Name="Alpha" Kind="InputPin" />
-              <Pin Id="BhWMlGtzTiOLSEPCV7zo1d" Name="Enabled" Kind="InputPin" />
-              <Pin Id="BFEenl1tNpkNhPxrroyx4e" Name="Output" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="408,341,25,19" Id="Qy12cW1zDBJMRfQUKp6wjl">
-              <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="In" />
-              </p:NodeReference>
-              <Pin Id="CxbnipgLXWLMvOTzlg4a0R" Name="Value" Kind="InputPin" />
-              <Pin Id="HDAueqal9jfNI9dQoa5qRx" Name="Output" Kind="OutputPin" />
-            </Node>
-            <Pad Id="SRdLyVqGTZcPQcH8aFtjER" Bounds="821,564,150,46" ShowValueBox="true" isIOBox="true" Value="needs to render in transparent stage">
-              <p:TypeAnnotation>
-                <Choice Kind="TypeFlag" Name="String" />
-              </p:TypeAnnotation>
-              <p:ValueBoxSettings>
-                <p:fontsize p:Type="Int32">9</p:fontsize>
-                <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
-              </p:ValueBoxSettings>
-            </Pad>
-            <Node Bounds="408,473,100,19" Id="GaEN7sKUX6cO6Un9nfuerf">
+            <Node Bounds="640,841,105,19" Id="GaEN7sKUX6cO6Un9nfuerf">
               <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastSymbolSource="VL.Stride.Rendering.EffectShaderNodes">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessNode" Name="MyParticleProvider" />
               </p:NodeReference>
-              <Pin Id="KXpNFmnRdQENf0dwS3bkQG" Name="Value" Kind="InputPin" />
+              <Pin Id="MeQ4JQvPPJpPc2bSYvt8RO" Name="Vertex ID" Kind="InputPin" />
+              <Pin Id="Pu0ahyOttZGMI1y347woVG" Name="VID" Kind="InputPin" />
               <Pin Id="NeKsOrRxkdPLnQObTquhS4" Name="Particle Size" Kind="InputPin" />
               <Pin Id="TxkJhZbvAm7OjQmhSOVQvP" Name="Particles Buffer" Kind="InputPin" />
               <Pin Id="A5AsCsVrPAaMOYF0ESU2Ya" Name="Random Values" Kind="InputPin" />
               <Pin Id="KFU2c3HkDkRQFtWlRFYMcE" Name="P Norm" Kind="InputPin" />
               <Pin Id="EFfcoEBeJa6ME1SkP42T4t" Name="Output" Kind="OutputPin" />
             </Node>
-            <ControlPoint Id="AHC3Ei8VQbiPO8izVVE2Yu" Bounds="449,778" />
-            <Pad Id="ApiWBzL5AjKQBGK2Rf0VGf" Comment="Material Extension Name" Bounds="224,604,177,15" ShowValueBox="true" isIOBox="true" Value="SphereImpostorMaterialExtension">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="TypeFlag" Name="String" />
-              </p:TypeAnnotation>
-            </Pad>
-            <ControlPoint Id="Rf9co0qPTV4Phyn12aoK6q" Bounds="481,449" />
-            <Node Bounds="162,644,65,19" Id="IbFdLXOYlhvLvujOS0OI2V">
+            <ControlPoint Id="AHC3Ei8VQbiPO8izVVE2Yu" Bounds="428,1208" />
+            <ControlPoint Id="Rf9co0qPTV4Phyn12aoK6q" Bounds="722,817" />
+            <Node Bounds="230,949,85,19" Id="IbFdLXOYlhvLvujOS0OI2V">
               <p:NodeReference LastCategoryFullName="Stride.Models.Meshes" LastSymbolSource="VL.Stride.Rendering.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="NullMesh" />
@@ -821,7 +757,7 @@
               <Pin Id="Ir18k9aDqXtMOYTm0uFZfI" Name="Material Extension Shader" Kind="InputPin" />
               <Pin Id="BoMIZMf1BmMOjlJM8y9L6h" Name="Output" Kind="OutputPin" />
             </Node>
-            <Node Bounds="153,476,68,26" Id="VC7SpK0o5zCQYf6UAzkPyL">
+            <Node Bounds="245,794,68,26" Id="VC7SpK0o5zCQYf6UAzkPyL">
               <p:NodeReference LastCategoryFullName="3D.AlignedBox" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="AlignedBox (Join)" />
@@ -830,17 +766,40 @@
               <Pin Id="HxfpV49Lqq9MmdYDuN7XlY" Name="Maximum" Kind="InputPin" />
               <Pin Id="UIAP1nv2k8VLCE4iUDXQTc" Name="Output" Kind="StateOutputPin" />
             </Node>
-            <Pad Id="SfbaVAVtjrlLHjq8kULyt0" Comment="Minimum" Bounds="154,382,35,43" ShowValueBox="true" isIOBox="true" Value="-5, -1, -5">
+            <Pad Id="SfbaVAVtjrlLHjq8kULyt0" Comment="Minimum" Bounds="246,700,35,43" ShowValueBox="true" isIOBox="true" Value="-5, -1, -5">
               <p:TypeAnnotation LastCategoryFullName="3D" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Vector3" />
               </p:TypeAnnotation>
             </Pad>
-            <Pad Id="FxthkIRAXWMO31hVVORVWd" Comment="Maximum" Bounds="261,381,35,43" ShowValueBox="true" isIOBox="true" Value="5, 5, 5">
+            <Pad Id="FxthkIRAXWMO31hVVORVWd" Comment="Maximum" Bounds="353,699,35,43" ShowValueBox="true" isIOBox="true" Value="5, 5, 5">
               <p:TypeAnnotation LastCategoryFullName="3D" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Vector3" />
               </p:TypeAnnotation>
             </Pad>
-            <Pad Id="EFbGpulzUPgMiOEcQq0fOK" Bounds="180,575" />
+            <Pad Id="EFbGpulzUPgMiOEcQq0fOK" Bounds="272,893" />
+            <Node Bounds="640,890,88,19" Id="C5Kiud6dRrDOzUGJrUOkFV">
+              <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastSymbolSource="VL.Stride.Rendering.EffectShaderNodes">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="ProcessNode" Name="SphereImpostor" />
+              </p:NodeReference>
+              <Pin Id="PFwk8VjSze5LiHXYDOKsjL" Name="Provider" Kind="InputPin" />
+              <Pin Id="FkwkQpaX5KoO3wiy8nFoyv" Name="Shading Color 0" Kind="InputPin" />
+              <Pin Id="PHSwqpIyoR2OI2zfObUGvJ" Name="World" Kind="InputPin" />
+              <Pin Id="AeBEXmDS50pMUnjFVosYeK" Name="Output" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="474,982,105,19" Id="MpcHgDOiRQyNMuFKuXTJRw">
+              <p:NodeReference LastCategoryFullName="Stride.Materials" LastSymbolSource="VL.Stride.Rendering.Nodes">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="ProcessAppFlag" Name="MaterialExtension" />
+                <CategoryReference Kind="Category" Name="Materials" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="HBzU9zRz7EJPf2cgsR9qbQ" Name="Material" Kind="InputPin" />
+              <Pin Id="Kqg9uzWEz4GLT6xOQ9PwQy" Name="Material Extension" Kind="InputPin" />
+              <Pin Id="FmRQzxAaJeOPT14T6uh4zo" Name="Vertex Addition" Kind="InputPin" />
+              <Pin Id="K6OA2ejrRzYLPge2lC8Fef" Name="Pixel Addition" Kind="InputPin" />
+              <Pin Id="HDnvz8kd4ytL3yKfSwpUSi" Name="Cutoff" Kind="InputPin" />
+              <Pin Id="OpBeV3cBNtPOeXz08hXgp5" Name="Output" Kind="OutputPin" />
+            </Node>
           </Canvas>
           <ProcessDefinition Id="OV42zxvJSXrOcc7IF1pVEB">
             <Fragment Id="MBXzQIHc1eiPDYPqpy7Mee" Patch="CZFIDMWPYHJQbFewVCJQDo" Enabled="true" />
@@ -850,25 +809,25 @@
           <Link Id="VSSWFIExUtYNe55nGr6NJx" Ids="DeoHqRmxbuBLRFTPMyIAm4,T8HWV3G7HJVLeLtbpxvYVi" IsHidden="true" />
           <Link Id="A7YUwaEDkgROhsApFJLCHr" Ids="BkfxRrj34XDOCb5nfZt21l,BMonosI7mIQL5iDL7qNnjW" IsHidden="true" />
           <Link Id="At32ujgPvo2M8YTqM0kmiQ" Ids="NqifurtphrvL43IIt3CVHF,QfYuwGUnBlBPtxW6YsUYUA" IsHidden="true" />
-          <Link Id="NMAEf6QOtCIQFuG7wY58mk" Ids="KSi7j2G32eJMwinFyFD7Hn,D6E9GHJJAUEPpO7Na9Zl1Y" />
-          <Link Id="INDTv7m7PGuMQDSjd8tDQX" Ids="HEt5ZuIifJoPjet0sCKAnu,ODob4CbEUVXO8cmtLiMdtc" />
-          <Link Id="G0vHC4mNVQVPM67Jcd4Dtb" Ids="LSaRtghPTjtLxuMLOhjvO4,H9ery95rnInPYtxIoqnQKr" />
-          <Link Id="Azq0RrBOwtlNd4ThO3JWsY" Ids="Vqf9wuJmZoSLmOTeEr6NDc,MWcUCDEKHyBL2UILeODshN" />
-          <Link Id="M6s5NlGihNsNXJTOiBCisY" Ids="BFEenl1tNpkNhPxrroyx4e,UwXXgu6T7nfNbVcjxYicOH" />
-          <Link Id="I1L0W5Ny9XkLpU2LSq4AcY" Ids="AF0cvKe07jePmfoKZpjtvQ,CxbnipgLXWLMvOTzlg4a0R" />
-          <Link Id="LM9C0Yk4GsPNw0ynth9lKs" Ids="SIRNI7PSspkLAFJ4F0Nzgm,NpDbnRkBJogP8nV8adtwMr" />
-          <Link Id="A4ibjJcdrLBMBoEImYULWV" Ids="EFfcoEBeJa6ME1SkP42T4t,MBiode4s1cOMRZM5ZnPRSG" />
-          <Link Id="Nmn3CBpzU6UQAPUMbgE4Be" Ids="KAnSujhgD1wPiLnXriVK1F,AHC3Ei8VQbiPO8izVVE2Yu" />
           <Link Id="JnTixJUIVgNLkWJb4NvZLa" Ids="AHC3Ei8VQbiPO8izVVE2Yu,QvJT4poD4GzOvaJ4Hz3dTV" IsHidden="true" />
-          <Link Id="HMZy4XoXFRtM9ixKdhLFhB" Ids="T8HWV3G7HJVLeLtbpxvYVi,EsWw5kSGiAQMoPCN5v3Av0" />
           <Link Id="RohH8hwakpyLX7lQViHQuV" Ids="OySo4puW8uhLZlTetVJw8i,TxkJhZbvAm7OjQmhSOVQvP" />
           <Link Id="TmtscuesYRIOiqNV5fET4n" Ids="QfYuwGUnBlBPtxW6YsUYUA,NeKsOrRxkdPLnQObTquhS4" />
-          <Link Id="DlAZfpJ3JhsPi3VvlqwpX0" Ids="HDAueqal9jfNI9dQoa5qRx,KXpNFmnRdQENf0dwS3bkQG" />
           <Link Id="PHJpylrX5tgQQfjRwbxcJi" Ids="Rf9co0qPTV4Phyn12aoK6q,A5AsCsVrPAaMOYF0ESU2Ya" />
           <Link Id="GJx0dfTTrCtPbvmBhMptVj" Ids="HGkbuJF9hSiMKFu5xuBFZb,Rf9co0qPTV4Phyn12aoK6q" IsHidden="true" />
+          <Link Id="SqczqqGWbm0NT4C4i9pAaT" Ids="BMonosI7mIQL5iDL7qNnjW,PAPacizBoPfQKfhOmj5zdo" />
+          <Link Id="K8p5VrakVQ0LWV9FFwsETf" Ids="BoMIZMf1BmMOjlJM8y9L6h,TrzxZWxkpj6NtcaSM7Xe3g" />
+          <Link Id="N2P7I5uAb8bPiEW4GvoC7H" Ids="SfbaVAVtjrlLHjq8kULyt0,DcIm7Ddq4W1PbbkYF6Hk9t" />
+          <Link Id="JuajDjFEX1NQDfJx5dp1F5" Ids="FxthkIRAXWMO31hVVORVWd,HxfpV49Lqq9MmdYDuN7XlY" />
+          <Link Id="TEeyVyDeGIHPx8zpKU9cCW" Ids="UIAP1nv2k8VLCE4iUDXQTc,EFbGpulzUPgMiOEcQq0fOK" />
+          <Link Id="KaAIz1cUbnoOgdFrJREyIK" Ids="EFbGpulzUPgMiOEcQq0fOK,Q7KQWsIYXNBNdO8ZdlALhn" />
           <Patch Id="CZFIDMWPYHJQbFewVCJQDo" Name="Create" ParticipatingElements="VC7SpK0o5zCQYf6UAzkPyL" />
           <Patch Id="Meh3N0W5wsHOur708dOzQK" Name="Update">
             <Pin Id="BkfxRrj34XDOCb5nfZt21l" Name="Count" Kind="InputPin" Bounds="636,543" />
+            <Pin Id="DeoHqRmxbuBLRFTPMyIAm4" Name="Color" Kind="InputPin" DefaultValue="1, 1, 1, 0">
+              <p:TypeAnnotation LastCategoryFullName="Color" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="RGBA" />
+              </p:TypeAnnotation>
+            </Pin>
             <Pin Id="NqifurtphrvL43IIt3CVHF" Name="Particle Size" Kind="InputPin" Bounds="861,428" DefaultValue="0.01">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
@@ -876,20 +835,16 @@
             </Pin>
             <Pin Id="D4kLwdH1ycLOMIeLtLuyhO" Name="Particles Buffer" Kind="InputPin" />
             <Pin Id="HGkbuJF9hSiMKFu5xuBFZb" Name="Random Values" Kind="InputPin" Bounds="482,452" />
-            <Pin Id="DeoHqRmxbuBLRFTPMyIAm4" Name="Color" Kind="InputPin" DefaultValue="1, 1, 1, 0">
-              <p:TypeAnnotation LastCategoryFullName="Color" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="TypeFlag" Name="RGBA" />
-              </p:TypeAnnotation>
-            </Pin>
             <Pin Id="QvJT4poD4GzOvaJ4Hz3dTV" Name="Entity" Kind="OutputPin" Bounds="970,849" />
           </Patch>
-          <Link Id="SqczqqGWbm0NT4C4i9pAaT" Ids="BMonosI7mIQL5iDL7qNnjW,PAPacizBoPfQKfhOmj5zdo" />
-          <Link Id="BBaWqVtrrReNlbkF1Bs94C" Ids="ApiWBzL5AjKQBGK2Rf0VGf,OJZonhDUqSXNEwtEaE0Vyx" />
-          <Link Id="K8p5VrakVQ0LWV9FFwsETf" Ids="BoMIZMf1BmMOjlJM8y9L6h,TrzxZWxkpj6NtcaSM7Xe3g" />
-          <Link Id="N2P7I5uAb8bPiEW4GvoC7H" Ids="SfbaVAVtjrlLHjq8kULyt0,DcIm7Ddq4W1PbbkYF6Hk9t" />
-          <Link Id="JuajDjFEX1NQDfJx5dp1F5" Ids="FxthkIRAXWMO31hVVORVWd,HxfpV49Lqq9MmdYDuN7XlY" />
-          <Link Id="TEeyVyDeGIHPx8zpKU9cCW" Ids="UIAP1nv2k8VLCE4iUDXQTc,EFbGpulzUPgMiOEcQq0fOK" />
-          <Link Id="KaAIz1cUbnoOgdFrJREyIK" Ids="EFbGpulzUPgMiOEcQq0fOK,Q7KQWsIYXNBNdO8ZdlALhn" />
+          <Link Id="QzO3ukekhKWMiAQ0ywJmqA" Ids="EFfcoEBeJa6ME1SkP42T4t,PFwk8VjSze5LiHXYDOKsjL" />
+          <Link Id="N3VZ1rhMPg2QYoWruafctA" Ids="SIRNI7PSspkLAFJ4F0Nzgm,HBzU9zRz7EJPf2cgsR9qbQ" />
+          <Link Id="UPndFQsSY92Ob6gWGvdsbC" Ids="OpBeV3cBNtPOeXz08hXgp5,NpDbnRkBJogP8nV8adtwMr" />
+          <Link Id="GCB2BhExgYaOw6wb9ki3N7" Ids="AeBEXmDS50pMUnjFVosYeK,Kqg9uzWEz4GLT6xOQ9PwQy" />
+          <Link Id="I5qOHWMo8HkMiHiU6AMGNa" Ids="KAnSujhgD1wPiLnXriVK1F,AHC3Ei8VQbiPO8izVVE2Yu" />
+          <Link Id="ObEvBbKRGkHOFauCxcHsQ1" Ids="T8HWV3G7HJVLeLtbpxvYVi,UdnmNGnHlIFOMEmXZcOwzm" />
+          <Link Id="CGaiOlZZxxELSoeGhXPnBL" Ids="AF0cvKe07jePmfoKZpjtvQ,MBiode4s1cOMRZM5ZnPRSG" />
+          <Link Id="TBwnFgi8MpsL84l2Y9kLfa" Ids="LSaRtghPTjtLxuMLOhjvO4,MWcUCDEKHyBL2UILeODshN" />
         </Patch>
       </Node>
     </Canvas>
@@ -910,7 +865,7 @@
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SceneWindow" />
             </p:NodeReference>
-            <Pin Id="KB5Y8vreWQpLa79zg7iUUW" Name="Bounds" Kind="InputPin" DefaultValue="1166, 107, 648, 628">
+            <Pin Id="KB5Y8vreWQpLa79zg7iUUW" Name="Bounds" Kind="InputPin" DefaultValue="1165.6, 106.4, 648, 628">
               <p:TypeAnnotation LastCategoryFullName="2D" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Rectangle" />
               </p:TypeAnnotation>
@@ -963,6 +918,7 @@
             <Pin Id="BxsGzFyqCmgMSQh70PtOA9" Name="Initial Pitch" Kind="InputPin" />
             <Pin Id="J8DOWOxzWXoOmP5U3eQxbM" Name="Initial Distance" Kind="InputPin" />
             <Pin Id="DHjJ8leVagLNoEfDrpG7mz" Name="Initial Vertical Field Of View" Kind="InputPin" />
+            <Pin Id="QEAm4zX9KYlPotsLH096gf" Name="Projection" Kind="InputPin" />
             <Pin Id="MTIInMya2HxOLwlAU3rJhO" Name="Near Clip Plane" Kind="InputPin" />
             <Pin Id="NPE78i1cdZWNMvJ4HHbmxI" Name="Far Clip Plane" Kind="InputPin" />
             <Pin Id="S8kElJ7GBXMLotqy2TJp5O" Name="Aspect Ratio" Kind="InputPin" />
@@ -1063,17 +1019,17 @@
             <Pin Id="CgNRKW3XAR0QdQPVyrBWTt" Name="Intensity" Kind="InputPin" />
             <Pin Id="K7xIk53LOMwMWtqHyMVqN1" Name="Sample Bias" Kind="InputPin" />
             <Pin Id="PsHyeV9Cm6IMtUiFIlEUtQ" Name="Sample Radius" Kind="InputPin" />
-            <Pin Id="KQaChHO4t6DPfpRr9NaBQT" Name="Blur Count" Kind="InputPin" DefaultValue="2">
+            <Pin Id="KQaChHO4t6DPfpRr9NaBQT" Name="Blur Count" Kind="InputPin" DefaultValue="3">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Integer32" />
               </p:TypeAnnotation>
             </Pin>
-            <Pin Id="Or8zCx2ja8vLDRcWIaSxEv" Name="Blur Radius" Kind="InputPin" DefaultValue="1.96">
+            <Pin Id="Or8zCx2ja8vLDRcWIaSxEv" Name="Blur Radius" Kind="InputPin" DefaultValue="2.02">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
-            <Pin Id="KE9EyF6Zt5POpFnhCirYZH" Name="Edge Sharpness" Kind="InputPin" DefaultValue="2.84">
+            <Pin Id="KE9EyF6Zt5POpFnhCirYZH" Name="Edge Sharpness" Kind="InputPin" DefaultValue="1.19">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
@@ -1082,12 +1038,12 @@
             <Pin Id="Cm0aBDCLISqMXHRZYiL6bI" Name="Enabled" Kind="InputPin" />
             <Pin Id="HooovIuaSNDOFwEuB81EA9" Name="Output" Kind="OutputPin" />
           </Node>
-          <Pad Id="AuzdO8Bvd4zQDpCiyP5csh" Comment="Intensity" Bounds="767,814,35,15" ShowValueBox="true" isIOBox="true" Value="0.31">
+          <Pad Id="AuzdO8Bvd4zQDpCiyP5csh" Comment="Intensity" Bounds="767,814,35,15" ShowValueBox="true" isIOBox="true" Value="0.27">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="PkdGhi7CkptOCvpSqZ12w8" Comment="Sample Bias" Bounds="786,839,35,15" ShowValueBox="true" isIOBox="true" Value="0.008">
+          <Pad Id="PkdGhi7CkptOCvpSqZ12w8" Comment="Sample Bias" Bounds="786,839,35,15" ShowValueBox="true" isIOBox="true" Value="0.02">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
@@ -1096,12 +1052,12 @@
               <p:stepsize p:Type="Single">0.001</p:stepsize>
             </p:ValueBoxSettings>
           </Pad>
-          <Pad Id="R08q2qQCO5MOOb1GtQtGW8" Comment="Sample Radius" Bounds="805,864,35,15" ShowValueBox="true" isIOBox="true" Value="0.86">
+          <Pad Id="R08q2qQCO5MOOb1GtQtGW8" Comment="Sample Radius" Bounds="805,864,35,15" ShowValueBox="true" isIOBox="true" Value="1">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="SWZG93fF5yaMd0MXP2Whh3" Comment="Projection Scale" Bounds="747,783,35,15" ShowValueBox="true" isIOBox="true" Value="0.54">
+          <Pad Id="SWZG93fF5yaMd0MXP2Whh3" Comment="Projection Scale" Bounds="747,783,35,15" ShowValueBox="true" isIOBox="true" Value="0.52">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
@@ -1352,7 +1308,6 @@
         <Link Id="CcuUrtCVPGCQao7Q5OMIhg" Ids="SWZG93fF5yaMd0MXP2Whh3,MaOjwkKPpGFMyniI77YF7n" />
         <Link Id="NO1FVLuJ2vWPF7m5lWDPv7" Ids="VInmUcm4gjzN4yISeihyGR,Pf8CVxye3hXMn8U6n4AoWU" />
         <Link Id="VxmTVAzs21FLv5y2wHTj5X" Ids="Iu5CL7gT18pMBp4nebKEcH,SVr9kN8HJoRPY1VRfVWXOm" />
-        <Link Id="IpegqQ4ARxnMczqXbzQJ3y" Ids="AdsVzstQvCAOYN0ZRpw7xA,OqsqXmszer9PjnyDAaUvq6" />
         <Link Id="ToVIAnXVTVEL5gGuiA0H0f" Ids="HooovIuaSNDOFwEuB81EA9,MkoRbVloq5eNuYyWmTnFZp" />
         <Link Id="HlnOkFrqhxfPs1dXyd8o8N" Ids="LxtFQXkjrX7OPDKC4A8GnZ,JCRP24cF7HYN6TE088sBTL" />
         <Link Id="KQ0MS8HqYXwLyiFSI1RZns" Ids="I3vo1B7MB1FLdC07UpGxXh,FnsEaAiC89CPFOz4eZK61o" />
@@ -1375,12 +1330,13 @@
         <Link Id="OzDK0dCemt8MyDCi2kYVro" Ids="GyeQBzlrbAJLPnfqNpbBpu,GXAIkjqI4F3Lnt0U7X7aqB" />
         <Link Id="LwbA8EuOagzLkweOLvjjxA" Ids="EMb7gudFzAYQPrOX7ShRac,UlDCKgyWck3MPe8TFe2N5T" />
         <Link Id="PyyMzCYFHFlMkgZvVVOQMZ" Ids="T1K0o7K7QTIO7eSZOhelbJ,PcSTfCVnZwyOdMKon7dyzF" />
+        <Link Id="LF6sxrVfAxuPiRGsAWAMUn" Ids="AdsVzstQvCAOYN0ZRpw7xA,OqsqXmszer9PjnyDAaUvq6" />
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="Dy0zFD8uTmYMzk069ST9sM" Location="VL.CoreLib" Version="2021.4.0-0310-gbc7bb47474" />
-  <NugetDependency Id="Lp16f7qHFemQFVwR2545bJ" Location="VL.Stride.Runtime" Version="2021.4.0-0314-g978b76b064" />
+  <NugetDependency Id="Dy0zFD8uTmYMzk069ST9sM" Location="VL.CoreLib" Version="2021.4.0-0365-g698d9b47a2" />
+  <NugetDependency Id="Lp16f7qHFemQFVwR2545bJ" Location="VL.Stride.Runtime" Version="2021.4.0-0367-ge098dee0dd" />
   <PlatformDependency Id="Op16f7qHFemQFVwR2545bJ" Location="VL.Stride.Runtime.dll" />
-  <NugetDependency Id="IS68NBjN33xNudq4Meb8FU" Location="VL.EditingFramework" Version="2021.4.0-0310-gbc7bb47474" />
-  <NugetDependency Id="N2EmPdu0p2zMRRd7X1tgPt" Location="VL.Stride.Windows" Version="2021.4.0-0314-g978b76b064" />
+  <NugetDependency Id="IS68NBjN33xNudq4Meb8FU" Location="VL.EditingFramework" Version="2021.4.0-0365-g698d9b47a2" />
+  <NugetDependency Id="N2EmPdu0p2zMRRd7X1tgPt" Location="VL.Stride.Windows" Version="2021.4.0-0367-ge098dee0dd" />
 </Document>

--- a/packages/VL.Stride.Runtime/help/Rendering/Example GPU Particle System with PBR.vl
+++ b/packages/VL.Stride.Runtime/help/Rendering/Example GPU Particle System with PBR.vl
@@ -353,7 +353,6 @@
               <Pin Id="NaZSKq6ePIwP4hvKtZGKeK" Name="Color" Kind="InputPin" />
               <Pin Id="MiIJPMJqesuNjDzVPosxtt" Name="Particle Size" Kind="InputPin" />
               <Pin Id="S07aaiMTWKUQa8dU7ClGwG" Name="Particles Buffer" Kind="InputPin" />
-              <Pin Id="B8kAGh4ElIEOaRQ6mmrdes" Name="Random Values" Kind="InputPin" />
               <Pin Id="NMSKqU2FaCrNuVViGbIXHb" Name="Entity" Kind="OutputPin" />
             </Node>
             <Node Bounds="443,398,145,19" Id="CjjLTVliM2iPbUlsLXFX5O">
@@ -378,7 +377,7 @@
               </p:TypeAnnotation>
             </Pad>
             <ControlPoint Id="EPrxzVSx1udNwF2bch606t" Bounds="491,654" />
-            <ControlPoint Id="OptzYO0A4m3OH0DBziD8Av" Bounds="582,670" />
+            <ControlPoint Id="OptzYO0A4m3OH0DBziD8Av" Bounds="514,670" />
             <Node Bounds="707,592,249,185" Id="CIWI557NWKXOwLmEwr5K26">
               <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
@@ -410,7 +409,7 @@
             <ControlPoint Id="OzwKFu2T2uALuwxUkv1cBc" Bounds="365,644" />
             <ControlPoint Id="EBPU249yxgHMy1NHqYXum1" Bounds="391,675" />
             <ControlPoint Id="HcBnn9rFHlVNGNYrMZgX8i" Bounds="331,476" />
-            <ControlPoint Id="RDYKYxoDjONOAzIgS1OmMg" Bounds="549,635" />
+            <ControlPoint Id="RDYKYxoDjONOAzIgS1OmMg" Bounds="560,663" />
             <Node Bounds="329,533,30,19" Id="TsGZHhHBslYPWCwSuqFe63">
               <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -537,6 +536,13 @@
           <Link Id="Gh0m0QqKeKaQCEZUXJ8zAQ" Ids="RmvKtdSwXbnMJGKrKgTO8T,E8miLADhhL0LTMeZH0R2hy" />
           <Link Id="QQ8A1NcYrcsNbtJFtqMEqS" Ids="DXvu4XEsk0cNV1KCTlfZc4,VS5yrZmXED8LoFgpyzGshW" />
           <Link Id="LZD82fpfXsFLsXt2sa1bix" Ids="NMSKqU2FaCrNuVViGbIXHb,Hogn5egW1I1Lj6st00Aqyv" />
+          <Link Id="GY5J6HotcK6OGcNyy5BL9V" Ids="CugCthXGkaMMMPHXnKuGW9,SOTCOKkXx8tMptyCW1duKJ" />
+          <Link Id="U1mBOJtNnFqPDPUjO3fSHG" Ids="DLOD47A3Q8fO69aFLa1yjo,OhVkCRHmwcZMpzs9UO49OJ" />
+          <Link Id="KtnrRsYHTOXL93OgEx8nxO" Ids="NVODfm9pUk5QGINMKk7OIk,Odwsl2mUCc1OsdAMtG0TbY" />
+          <Link Id="BAb5mgeIyQAN60qP6c23wZ" Ids="C23E0J6uwawNKpr5CL04qX,I41F02pqQEMLA6WjrFUXHH" />
+          <Link Id="GWgr68QFee4Px5KDmUt3CQ" Ids="ASmLozRcz6mOTcbzGoncws,BXoCtKyb4VJPtVhZWLa81Y" />
+          <Link Id="GpLPY320di3PorvcaJA1Yv" Ids="RmvKtdSwXbnMJGKrKgTO8T,EmDFUPSjEvyMRnRVQbD7Hb" />
+          <Link Id="JJmvoGhEN7fMrmZj0vj3nx" Ids="SfHwtwber4LO2bAWEi4yom,PlRksMIKUuoPs0vgn30WmP" />
           <Patch Id="VPepoyTGHcpNbNMGVHP75i" Name="Create" />
           <Patch Id="JUnu5cB51WRMyhFWGYtonM" Name="Update">
             <Pin Id="FEv2iXLKi0pQFH4bVDTxhJ" Name="Reset" Kind="InputPin" Bounds="381,363" />
@@ -547,18 +553,10 @@
                 <Choice Kind="TypeFlag" Name="Integer32" />
               </p:TypeAnnotation>
             </Pin>
-            <Pin Id="TJ1GFM6KZkcOsLbwvITobN" Name="Particle Size" Kind="InputPin" Bounds="659,413" />
             <Pin Id="IOibA0oX0wJOI21kTFx32W" Name="Color" Kind="InputPin" Bounds="630,422" />
+            <Pin Id="TJ1GFM6KZkcOsLbwvITobN" Name="Particle Size" Kind="InputPin" Bounds="659,413" />
             <Pin Id="NybBGcRTM6NMQhZo0tTEV4" Name="Entity" Kind="OutputPin" Bounds="317,684" />
           </Patch>
-          <Link Id="GY5J6HotcK6OGcNyy5BL9V" Ids="CugCthXGkaMMMPHXnKuGW9,SOTCOKkXx8tMptyCW1duKJ" />
-          <Link Id="U1mBOJtNnFqPDPUjO3fSHG" Ids="DLOD47A3Q8fO69aFLa1yjo,OhVkCRHmwcZMpzs9UO49OJ" />
-          <Link Id="KtnrRsYHTOXL93OgEx8nxO" Ids="NVODfm9pUk5QGINMKk7OIk,Odwsl2mUCc1OsdAMtG0TbY" />
-          <Link Id="BAb5mgeIyQAN60qP6c23wZ" Ids="C23E0J6uwawNKpr5CL04qX,I41F02pqQEMLA6WjrFUXHH" />
-          <Link Id="GWgr68QFee4Px5KDmUt3CQ" Ids="ASmLozRcz6mOTcbzGoncws,BXoCtKyb4VJPtVhZWLa81Y" />
-          <Link Id="GpLPY320di3PorvcaJA1Yv" Ids="RmvKtdSwXbnMJGKrKgTO8T,EmDFUPSjEvyMRnRVQbD7Hb" />
-          <Link Id="JJmvoGhEN7fMrmZj0vj3nx" Ids="SfHwtwber4LO2bAWEi4yom,PlRksMIKUuoPs0vgn30WmP" />
-          <Link Id="Bsua0AtxkKLOY1Raxdsgpg" Ids="SfHwtwber4LO2bAWEi4yom,B8kAGh4ElIEOaRQ6mmrdes" />
         </Patch>
       </Node>
       <!--
@@ -684,11 +682,11 @@
         </p:NodeReference>
         <Patch Id="TNXyJkNaFm8LsFl52SuweE">
           <Canvas Id="LiFafMZE7fxM02SmnaR90y" CanvasType="Group">
-            <ControlPoint Id="OySo4puW8uhLZlTetVJw8i" Bounds="702,785" />
-            <ControlPoint Id="T8HWV3G7HJVLeLtbpxvYVi" Bounds="393,768" />
-            <ControlPoint Id="BMonosI7mIQL5iDL7qNnjW" Bounds="156,873" />
-            <ControlPoint Id="QfYuwGUnBlBPtxW6YsUYUA" Bounds="683,743" />
-            <Node Bounds="357,1123,165,19" Id="OOKIYjpKbILOfBMYmg8R5g">
+            <ControlPoint Id="OySo4puW8uhLZlTetVJw8i" Bounds="704,406" />
+            <ControlPoint Id="T8HWV3G7HJVLeLtbpxvYVi" Bounds="420,352" />
+            <ControlPoint Id="BMonosI7mIQL5iDL7qNnjW" Bounds="148,437" />
+            <ControlPoint Id="QfYuwGUnBlBPtxW6YsUYUA" Bounds="609,390" />
+            <Node Bounds="373,688,165,19" Id="OOKIYjpKbILOfBMYmg8R5g">
               <p:NodeReference LastCategoryFullName="Stride.Models" LastSymbolSource="VL.Stride.Engine.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="MeshEntity" />
@@ -707,17 +705,17 @@
               <Pin Id="D6E9GHJJAUEPpO7Na9Zl1Y" Name="Enabled" Kind="InputPin" />
               <Pin Id="KAnSujhgD1wPiLnXriVK1F" Name="Entity" Kind="OutputPin" />
             </Node>
-            <Pad Id="AF0cvKe07jePmfoKZpjtvQ" Comment="Metalness" Bounds="413,795,35,15" ShowValueBox="true" isIOBox="true" Value="0.72">
+            <Pad Id="AF0cvKe07jePmfoKZpjtvQ" Comment="Metalness" Bounds="440,379,35,15" ShowValueBox="true" isIOBox="true" Value="0.72">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pad>
-            <Pad Id="LSaRtghPTjtLxuMLOhjvO4" Comment="Roughness" Bounds="433,824,36,15" ShowValueBox="true" isIOBox="true" Value="0.7">
+            <Pad Id="LSaRtghPTjtLxuMLOhjvO4" Comment="Roughness" Bounds="460,408,36,15" ShowValueBox="true" isIOBox="true" Value="0.7">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pad>
-            <Node Bounds="391,846,85,19" Id="AdDUxIGmXjHPRqn4TNKT5Q">
+            <Node Bounds="418,430,85,19" Id="AdDUxIGmXjHPRqn4TNKT5Q">
               <p:NodeReference LastCategoryFullName="Stride.Materials" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="PBRMaterial" />
@@ -729,22 +727,17 @@
               <Pin Id="QlESHeLYkX3NcPZROPceCZ" Name="Cull Mode" Kind="InputPin" />
               <Pin Id="SIRNI7PSspkLAFJ4F0Nzgm" Name="Output" Kind="OutputPin" />
             </Node>
-            <Node Bounds="591,864,105,19" Id="GaEN7sKUX6cO6Un9nfuerf">
+            <Node Bounds="607,429,-23,19" Id="GaEN7sKUX6cO6Un9nfuerf">
               <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastSymbolSource="VL.Stride.Rendering.EffectShaderNodes">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessNode" Name="MyParticleProvider" />
               </p:NodeReference>
-              <Pin Id="MeQ4JQvPPJpPc2bSYvt8RO" Name="Vertex ID" Kind="InputPin" />
-              <Pin Id="Pu0ahyOttZGMI1y347woVG" Name="VID" Kind="InputPin" />
               <Pin Id="NeKsOrRxkdPLnQObTquhS4" Name="Particle Size" Kind="InputPin" />
               <Pin Id="TxkJhZbvAm7OjQmhSOVQvP" Name="Particles Buffer" Kind="InputPin" />
-              <Pin Id="A5AsCsVrPAaMOYF0ESU2Ya" Name="Random Values" Kind="InputPin" />
-              <Pin Id="KFU2c3HkDkRQFtWlRFYMcE" Name="P Norm" Kind="InputPin" />
               <Pin Id="EFfcoEBeJa6ME1SkP42T4t" Name="Output" Kind="OutputPin" />
             </Node>
-            <ControlPoint Id="AHC3Ei8VQbiPO8izVVE2Yu" Bounds="358,1183" />
-            <ControlPoint Id="Rf9co0qPTV4Phyn12aoK6q" Bounds="722,817" />
-            <Node Bounds="230,967,85,19" Id="IbFdLXOYlhvLvujOS0OI2V">
+            <ControlPoint Id="AHC3Ei8VQbiPO8izVVE2Yu" Bounds="374,748" />
+            <Node Bounds="170,494,10,19" Id="IbFdLXOYlhvLvujOS0OI2V">
               <p:NodeReference LastCategoryFullName="Stride.Models.Meshes" LastSymbolSource="VL.Stride.Rendering.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="NullMesh" />
@@ -753,11 +746,9 @@
               <Pin Id="PAPacizBoPfQKfhOmj5zdo" Name="Count" Kind="InputPin" />
               <Pin Id="B4v9EDder8WOA7IVSufjRu" Name="Topology" Kind="InputPin" />
               <Pin Id="Q7KQWsIYXNBNdO8ZdlALhn" Name="Bounding Box" Kind="InputPin" />
-              <Pin Id="OJZonhDUqSXNEwtEaE0Vyx" Name="Material Extension Name" Kind="InputPin" />
-              <Pin Id="Ir18k9aDqXtMOYTm0uFZfI" Name="Material Extension Shader" Kind="InputPin" />
               <Pin Id="BoMIZMf1BmMOjlJM8y9L6h" Name="Output" Kind="OutputPin" />
             </Node>
-            <Node Bounds="245,794,68,26" Id="VC7SpK0o5zCQYf6UAzkPyL">
+            <Node Bounds="260,353,68,26" Id="VC7SpK0o5zCQYf6UAzkPyL">
               <p:NodeReference LastCategoryFullName="3D.AlignedBox" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="AlignedBox (Join)" />
@@ -766,29 +757,28 @@
               <Pin Id="HxfpV49Lqq9MmdYDuN7XlY" Name="Maximum" Kind="InputPin" />
               <Pin Id="UIAP1nv2k8VLCE4iUDXQTc" Name="Output" Kind="StateOutputPin" />
             </Node>
-            <Pad Id="SfbaVAVtjrlLHjq8kULyt0" Comment="Minimum" Bounds="246,700,35,43" ShowValueBox="true" isIOBox="true" Value="-5, -1, -5">
+            <Pad Id="SfbaVAVtjrlLHjq8kULyt0" Comment="Minimum" Bounds="261,259,35,43" ShowValueBox="true" isIOBox="true" Value="-5, -1, -5">
               <p:TypeAnnotation LastCategoryFullName="3D" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Vector3" />
               </p:TypeAnnotation>
             </Pad>
-            <Pad Id="FxthkIRAXWMO31hVVORVWd" Comment="Maximum" Bounds="353,699,35,43" ShowValueBox="true" isIOBox="true" Value="5, 5, 5">
+            <Pad Id="FxthkIRAXWMO31hVVORVWd" Comment="Maximum" Bounds="368,258,35,43" ShowValueBox="true" isIOBox="true" Value="5, 5, 5">
               <p:TypeAnnotation LastCategoryFullName="3D" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Vector3" />
               </p:TypeAnnotation>
             </Pad>
-            <Pad Id="EFbGpulzUPgMiOEcQq0fOK" Bounds="272,893" />
-            <Node Bounds="440,937,88,19" Id="C5Kiud6dRrDOzUGJrUOkFV">
+            <Pad Id="EFbGpulzUPgMiOEcQq0fOK" Bounds="262,421" />
+            <Node Bounds="607,470,10,19" Id="C5Kiud6dRrDOzUGJrUOkFV">
               <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastSymbolSource="VL.Stride.Rendering.EffectShaderNodes">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessNode" Name="SphereImpostor" />
               </p:NodeReference>
-              <Pin Id="PFwk8VjSze5LiHXYDOKsjL" Name="Provider" Kind="InputPin" />
-              <Pin Id="FkwkQpaX5KoO3wiy8nFoyv" Name="Shading Color 0" Kind="InputPin" />
-              <Pin Id="Tmtra6ouKaCL5ViIz66inV" Name="Scaling" Kind="InputPin" />
-              <Pin Id="PHSwqpIyoR2OI2zfObUGvJ" Name="World" Kind="InputPin" />
+              <Pin Id="PyqNfefoCZENtKM3ZU6tJp" Name="Provider" Kind="InputPin" />
+              <Pin Id="TwY62Qnt7T7NTVS6qIn7Ed" Name="Shading Color 0" Kind="InputPin" />
+              <Pin Id="FvOenGIj1AJMFTE4ztGmtF" Name="World" Kind="InputPin" />
               <Pin Id="AeBEXmDS50pMUnjFVosYeK" Name="Output" Kind="OutputPin" />
             </Node>
-            <Node Bounds="414,1026,105,19" Id="MpcHgDOiRQyNMuFKuXTJRw">
+            <Node Bounds="419,593,66,19" Id="MpcHgDOiRQyNMuFKuXTJRw">
               <p:NodeReference LastCategoryFullName="Stride.Materials" LastSymbolSource="VL.Stride.Rendering.Nodes">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="MaterialExtension" />
@@ -796,12 +786,10 @@
               </p:NodeReference>
               <Pin Id="HBzU9zRz7EJPf2cgsR9qbQ" Name="Material" Kind="InputPin" />
               <Pin Id="Kqg9uzWEz4GLT6xOQ9PwQy" Name="Material Extension" Kind="InputPin" />
-              <Pin Id="FmRQzxAaJeOPT14T6uh4zo" Name="Vertex Addition" Kind="InputPin" />
-              <Pin Id="K6OA2ejrRzYLPge2lC8Fef" Name="Pixel Addition" Kind="InputPin" />
               <Pin Id="HDnvz8kd4ytL3yKfSwpUSi" Name="Cutoff" Kind="InputPin" />
               <Pin Id="OpBeV3cBNtPOeXz08hXgp5" Name="Output" Kind="OutputPin" />
             </Node>
-            <Pad Id="JucKjnP0EMaMlvbV9Rs9Gt" Comment="Cutoff" Bounds="557,964,35,35" ShowValueBox="true" isIOBox="true" Value="True">
+            <Pad Id="JucKjnP0EMaMlvbV9Rs9Gt" Comment="Cutoff" Bounds="641,538,35,35" ShowValueBox="true" isIOBox="true" Value="True">
               <p:TypeAnnotation>
                 <Choice Kind="TypeFlag" Name="Boolean" />
                 <FullNameCategoryReference ID="Primitive" />
@@ -822,8 +810,6 @@
           <Link Id="JnTixJUIVgNLkWJb4NvZLa" Ids="AHC3Ei8VQbiPO8izVVE2Yu,QvJT4poD4GzOvaJ4Hz3dTV" IsHidden="true" />
           <Link Id="RohH8hwakpyLX7lQViHQuV" Ids="OySo4puW8uhLZlTetVJw8i,TxkJhZbvAm7OjQmhSOVQvP" />
           <Link Id="TmtscuesYRIOiqNV5fET4n" Ids="QfYuwGUnBlBPtxW6YsUYUA,NeKsOrRxkdPLnQObTquhS4" />
-          <Link Id="PHJpylrX5tgQQfjRwbxcJi" Ids="Rf9co0qPTV4Phyn12aoK6q,A5AsCsVrPAaMOYF0ESU2Ya" />
-          <Link Id="GJx0dfTTrCtPbvmBhMptVj" Ids="HGkbuJF9hSiMKFu5xuBFZb,Rf9co0qPTV4Phyn12aoK6q" IsHidden="true" />
           <Link Id="SqczqqGWbm0NT4C4i9pAaT" Ids="BMonosI7mIQL5iDL7qNnjW,PAPacizBoPfQKfhOmj5zdo" />
           <Link Id="K8p5VrakVQ0LWV9FFwsETf" Ids="BoMIZMf1BmMOjlJM8y9L6h,TrzxZWxkpj6NtcaSM7Xe3g" />
           <Link Id="N2P7I5uAb8bPiEW4GvoC7H" Ids="SfbaVAVtjrlLHjq8kULyt0,DcIm7Ddq4W1PbbkYF6Hk9t" />
@@ -844,18 +830,17 @@
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="D4kLwdH1ycLOMIeLtLuyhO" Name="Particles Buffer" Kind="InputPin" />
-            <Pin Id="HGkbuJF9hSiMKFu5xuBFZb" Name="Random Values" Kind="InputPin" Bounds="482,452" />
             <Pin Id="QvJT4poD4GzOvaJ4Hz3dTV" Name="Entity" Kind="OutputPin" Bounds="970,849" />
           </Patch>
-          <Link Id="QzO3ukekhKWMiAQ0ywJmqA" Ids="EFfcoEBeJa6ME1SkP42T4t,PFwk8VjSze5LiHXYDOKsjL" />
           <Link Id="N3VZ1rhMPg2QYoWruafctA" Ids="SIRNI7PSspkLAFJ4F0Nzgm,HBzU9zRz7EJPf2cgsR9qbQ" />
           <Link Id="UPndFQsSY92Ob6gWGvdsbC" Ids="OpBeV3cBNtPOeXz08hXgp5,NpDbnRkBJogP8nV8adtwMr" />
-          <Link Id="GCB2BhExgYaOw6wb9ki3N7" Ids="AeBEXmDS50pMUnjFVosYeK,Kqg9uzWEz4GLT6xOQ9PwQy" />
           <Link Id="ObEvBbKRGkHOFauCxcHsQ1" Ids="T8HWV3G7HJVLeLtbpxvYVi,UdnmNGnHlIFOMEmXZcOwzm" />
           <Link Id="CGaiOlZZxxELSoeGhXPnBL" Ids="AF0cvKe07jePmfoKZpjtvQ,MBiode4s1cOMRZM5ZnPRSG" />
           <Link Id="TBwnFgi8MpsL84l2Y9kLfa" Ids="LSaRtghPTjtLxuMLOhjvO4,MWcUCDEKHyBL2UILeODshN" />
           <Link Id="VikwEqtd4f4PoSa43zZghy" Ids="JucKjnP0EMaMlvbV9Rs9Gt,HDnvz8kd4ytL3yKfSwpUSi" />
           <Link Id="QPIVW0iecAjNN6mXidRwqG" Ids="KAnSujhgD1wPiLnXriVK1F,AHC3Ei8VQbiPO8izVVE2Yu" />
+          <Link Id="SvjN6McdoJaN8kgFZxYrHS" Ids="EFfcoEBeJa6ME1SkP42T4t,PyqNfefoCZENtKM3ZU6tJp" />
+          <Link Id="EyBVagY1GSBM1oQnFmARHB" Ids="AeBEXmDS50pMUnjFVosYeK,Kqg9uzWEz4GLT6xOQ9PwQy" />
         </Patch>
       </Node>
     </Canvas>
@@ -876,7 +861,7 @@
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SceneWindow" />
             </p:NodeReference>
-            <Pin Id="KB5Y8vreWQpLa79zg7iUUW" Name="Bounds" Kind="InputPin" DefaultValue="1028, 46.4, 648, 628">
+            <Pin Id="KB5Y8vreWQpLa79zg7iUUW" Name="Bounds" Kind="InputPin" DefaultValue="1179.2, 66.4, 648, 628">
               <p:TypeAnnotation LastCategoryFullName="2D" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Rectangle" />
               </p:TypeAnnotation>
@@ -1149,7 +1134,7 @@
             <Pin Id="DM1eYOqLGGuLIjJ7i1fwqB" Name="Count" Kind="InputPin" />
             <Pin Id="Vzg0FN5vTBLPCW1MIV2fJv" Name="Output" Kind="OutputPin" />
           </Node>
-          <Pad Id="DVWOxOe5NvhQCUvZuisut5" Comment="Particle System Count" Bounds="629,108,35,15" ShowValueBox="true" isIOBox="true" Value="10">
+          <Pad Id="DVWOxOe5NvhQCUvZuisut5" Comment="Particle System Count" Bounds="629,108,35,15" ShowValueBox="true" isIOBox="true" Value="1">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="Integer32" />
             </p:TypeAnnotation>
@@ -1159,7 +1144,7 @@
               <Choice Kind="TypeFlag" Name="Vector3" />
             </p:TypeAnnotation>
           </Pad>
-          <Node Bounds="490,296,251,182" Id="TW6VW991stjNKhu2EOiHwj">
+          <Node Bounds="490,296,144,182" Id="TW6VW991stjNKhu2EOiHwj">
             <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
               <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
@@ -1181,36 +1166,13 @@
                 <Pin Id="PcDXhL8Gj44QNjkAGOUtOq" Name="Target Pos" Kind="InputPin" />
                 <Pin Id="VthTgTAWrZkLkY33G2c2oy" Name="Target Strength" Kind="InputPin" />
                 <Pin Id="SCg3Q62eZduPwJjvWjPEwx" Name="Count" Kind="InputPin" />
+                <Pin Id="SJuFSGm5oPqMZFdXdcyIJR" Name="Color" Kind="InputPin" />
                 <Pin Id="PcSTfCVnZwyOdMKon7dyzF" Name="Particle Size" Kind="InputPin" DefaultValue="0.01">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                   </p:TypeAnnotation>
                 </Pin>
-                <Pin Id="SJuFSGm5oPqMZFdXdcyIJR" Name="Color" Kind="InputPin" />
                 <Pin Id="P99cFvLHZpdNrXoVRTKUTG" Name="Entity" Kind="OutputPin" />
-              </Node>
-              <Node Bounds="664,368,65,19" Id="Bii0k6QA5TIMW1mD2hCIrR">
-                <p:NodeReference LastCategoryFullName="Color.RGBA" LastSymbolSource="CoreLibBasics.vl">
-                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                  <Choice Kind="OperationCallFlag" Name="FromHSV" />
-                </p:NodeReference>
-                <Pin Id="QSv7M2XeRPdQURekbiwhtZ" Name="Hue" Kind="InputPin" DefaultValue="0.06">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                    <Choice Kind="TypeFlag" Name="Float32" />
-                  </p:TypeAnnotation>
-                </Pin>
-                <Pin Id="QigFWIqojJqMnf1tBcGwkA" Name="Saturation" Kind="InputPin" DefaultValue="0.77">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                    <Choice Kind="TypeFlag" Name="Float32" />
-                  </p:TypeAnnotation>
-                </Pin>
-                <Pin Id="HwQVNj3rGoBOcZ6mcTjcKk" Name="Value" Kind="InputPin" DefaultValue="0.94">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                    <Choice Kind="TypeFlag" Name="Float32" />
-                  </p:TypeAnnotation>
-                </Pin>
-                <Pin Id="PVQjvEWeTPoOc4cDnDw1VT" Name="Alpha" Kind="InputPin" />
-                <Pin Id="LUPl9rNhEhWPaTbQCK6yrD" Name="Result" Kind="OutputPin" />
               </Node>
             </Patch>
           </Node>
@@ -1242,11 +1204,7 @@
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
-            <Pin Id="MgBnPRnujGuP5GfvURxQCX" Name="Pause" Kind="InputPin" DefaultValue="True">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="TypeFlag" Name="Boolean" />
-              </p:TypeAnnotation>
-            </Pin>
+            <Pin Id="MgBnPRnujGuP5GfvURxQCX" Name="Pause" Kind="InputPin" />
             <Pin Id="KUw7oDNXfCcL6ICjWhCJEJ" Name="Reset" Kind="ApplyPin" />
             <Pin Id="UaCod26nMVhLMlCZ4iaTdu" Name="Phase" Kind="OutputPin" />
             <Pin Id="IYJ4crpZztoMcfs4oRwp72" Name="On New Cycle" Kind="OutputPin" />
@@ -1279,11 +1237,34 @@
               <Choice Kind="TypeFlag" Name="Vector3" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="T1K0o7K7QTIO7eSZOhelbJ" Comment="Particle Size" Bounds="738,250,35,15" ShowValueBox="true" isIOBox="true" Value="0.02">
+          <Pad Id="T1K0o7K7QTIO7eSZOhelbJ" Comment="Particle Size" Bounds="665,381,35,15" ShowValueBox="true" isIOBox="true" Value="0.02">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
+          <Node Bounds="651,314,65,19" Id="Bii0k6QA5TIMW1mD2hCIrR">
+            <p:NodeReference LastCategoryFullName="Color.RGBA" LastSymbolSource="CoreLibBasics.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="OperationCallFlag" Name="FromHSV" />
+            </p:NodeReference>
+            <Pin Id="QSv7M2XeRPdQURekbiwhtZ" Name="Hue" Kind="InputPin" DefaultValue="0.06">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="Float32" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="QigFWIqojJqMnf1tBcGwkA" Name="Saturation" Kind="InputPin" DefaultValue="0.77">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="Float32" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="HwQVNj3rGoBOcZ6mcTjcKk" Name="Value" Kind="InputPin" DefaultValue="0.94">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="Float32" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="PVQjvEWeTPoOc4cDnDw1VT" Name="Alpha" Kind="InputPin" />
+            <Pin Id="LUPl9rNhEhWPaTbQCK6yrD" Name="Result" Kind="OutputPin" />
+          </Node>
         </Canvas>
         <Patch Id="E2tTERO72lSL6f0H5UhaiY" Name="Create" />
         <Patch Id="ICV52uyFDtcQM9Gi4jZAgC" Name="Update" />

--- a/packages/VL.Stride.Runtime/help/Rendering/Example Geometry Shader with PBR.vl
+++ b/packages/VL.Stride.Runtime/help/Rendering/Example Geometry Shader with PBR.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="IZNEdmWwsqTPmRYNCw6rdu" LanguageVersion="2021.4.0.325" Version="0.128">
-  <NugetDependency Id="UMjQW1rcsHzLbQEEvmlyux" Location="VL.CoreLib" Version="2021.4.0-0310-gbc7bb47474" />
+<Document xmlns:p="property" Id="IZNEdmWwsqTPmRYNCw6rdu" LanguageVersion="2021.4.0.365" Version="0.128">
+  <NugetDependency Id="UMjQW1rcsHzLbQEEvmlyux" Location="VL.CoreLib" Version="2021.4.0-0365-g698d9b47a2" />
   <Patch Id="E3ImUTd2YNGObBvmdtwudp">
     <Canvas Id="UxUkpQTPbkoLBVXkPUqMgv" DefaultCategory="Main" CanvasType="FullCategory">
       <!--
@@ -892,7 +892,7 @@
               <Pin Id="F5YpTWgB91INxmRHuoXkT0" Name="Material Extension Shader" Kind="InputPin" />
               <Pin Id="U8mO05nJJMsLi6T1mPkJTm" Name="Output" Kind="OutputPin" />
             </Node>
-            <Node Bounds="970,788,165,19" Id="OOKIYjpKbILOfBMYmg8R5g">
+            <Node Bounds="948,963,165,19" Id="OOKIYjpKbILOfBMYmg8R5g">
               <p:NodeReference LastCategoryFullName="Stride.Models" LastSymbolSource="VL.Stride.Engine.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="MeshEntity" />
@@ -911,7 +911,7 @@
               <Pin Id="D6E9GHJJAUEPpO7Na9Zl1Y" Name="Enabled" Kind="InputPin" />
               <Pin Id="KAnSujhgD1wPiLnXriVK1F" Name="Entity" Kind="OutputPin" />
             </Node>
-            <Pad Id="KSi7j2G32eJMwinFyFD7Hn" Comment="Enabled" Bounds="1151,744,35,35" ShowValueBox="true" isIOBox="true" Value="True">
+            <Pad Id="KSi7j2G32eJMwinFyFD7Hn" Comment="Enabled" Bounds="1282,864,35,35" ShowValueBox="true" isIOBox="true" Value="True">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Boolean" />
               </p:TypeAnnotation>
@@ -919,103 +919,66 @@
                 <p:buttonmode p:Assembly="VL.UI.Forms" p:Type="VL.HDE.PatchEditor.Editors.ButtonModeEnum">Toggle</p:buttonmode>
               </p:ValueBoxSettings>
             </Pad>
-            <Pad Id="AF0cvKe07jePmfoKZpjtvQ" Comment="Metalness" Bounds="886,464,35,15" ShowValueBox="true" isIOBox="true" Value="0.72">
+            <Pad Id="AF0cvKe07jePmfoKZpjtvQ" Comment="Metalness" Bounds="1156,597,35,15" ShowValueBox="true" isIOBox="true" Value="0.72">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pad>
-            <Pad Id="LSaRtghPTjtLxuMLOhjvO4" Comment="Roughness" Bounds="1200,570,35,15" ShowValueBox="true" isIOBox="true" Value="0.64">
+            <Pad Id="LSaRtghPTjtLxuMLOhjvO4" Comment="Roughness" Bounds="1212,645,35,15" ShowValueBox="true" isIOBox="true" Value="0.64">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
-              </p:TypeAnnotation>
-            </Pad>
-            <Pad Id="CgNtlM4Q7dbQbZN98ebrNn" Comment="Color" Bounds="1102,518,136,15" ShowValueBox="true" isIOBox="true" Value="0.7400002, 0.3848, 0.5552975, 1">
-              <p:TypeAnnotation LastCategoryFullName="Color" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="TypeFlag" Name="RGBA" />
               </p:TypeAnnotation>
             </Pad>
             <Node Bounds="1100,684,225,19" Id="AdDUxIGmXjHPRqn4TNKT5Q">
               <p:NodeReference LastCategoryFullName="Stride.Materials" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="PBRMaterial (Metallic)" />
+                <Choice Kind="ProcessAppFlag" Name="PBRMaterial" />
               </p:NodeReference>
-              <Pin Id="ODob4CbEUVXO8cmtLiMdtc" Name="Diffuse" Kind="InputPin" />
+              <Pin Id="TFtQ9hBOHvKLtoRMeUI1XV" Name="Color" Kind="InputPin" />
               <Pin Id="MBiode4s1cOMRZM5ZnPRSG" Name="Metalness" Kind="InputPin" />
               <Pin Id="MWcUCDEKHyBL2UILeODshN" Name="Roughness" Kind="InputPin" />
-              <Pin Id="JHCedbHb4guOn5tsK5GKtf" Name="Normal" Kind="InputPin" />
-              <Pin Id="DG3gbV55WpYP7EPYZSL9gu" Name="Displacement" Kind="InputPin" />
-              <Pin Id="KpI5J2pfMnLLDQ2PXq0n0L" Name="Tessellation" Kind="InputPin" />
-              <Pin Id="QvO7V4kb7hxMtTJt7Ejy0H" Name="Occlusion" Kind="InputPin" />
-              <Pin Id="PhZ0PzwHKYnN7B39c504uM" Name="Subsurface Scattering" Kind="InputPin" />
-              <Pin Id="Mvkee2NKPLfLWA7lOyHZUL" Name="Emissive" Kind="InputPin" />
               <Pin Id="UwXXgu6T7nfNbVcjxYicOH" Name="Transparency" Kind="InputPin" />
-              <Pin Id="TosC2e96dQ0MSay3FTVPdH" Name="Layers" Kind="InputPin" />
               <Pin Id="QlESHeLYkX3NcPZROPceCZ" Name="Cull Mode" Kind="InputPin" />
               <Pin Id="SIRNI7PSspkLAFJ4F0Nzgm" Name="Output" Kind="OutputPin" />
             </Node>
-            <Node Bounds="1100,589,49,19" Id="KH2K8K2ozjiLSPw3Bi8FnH">
-              <p:NodeReference LastCategoryFullName="Stride.Materials.Inputs" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="ColorIn" />
-                <CategoryReference Kind="Category" Name="Inputs" NeedsToBeDirectParent="true" />
-              </p:NodeReference>
-              <Pin Id="EsWw5kSGiAQMoPCN5v3Av0" Name="Value" Kind="InputPin" />
-              <Pin Id="TNJT8G3259kMRkUJY3yFAR" Name="Premultiply Alpha" Kind="InputPin" />
-              <Pin Id="HEt5ZuIifJoPjet0sCKAnu" Name="Output" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="1198,603,25,19" Id="JvoFK8NRAWwMh1N4BkZ4XB">
-              <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="In" />
-              </p:NodeReference>
-              <Pin Id="H9ery95rnInPYtxIoqnQKr" Name="Value" Kind="InputPin" />
-              <Pin Id="Vqf9wuJmZoSLmOTeEr6NDc" Name="Output" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="1280,630,54,19" Id="FEQdmsPifWeOkFdIGfp37A">
-              <p:NodeReference LastCategoryFullName="Stride.Materials.MiscAttributes.Transparency" LastSymbolSource="VL.Stride.Rendering.Nodes">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <CategoryReference Kind="Category" Name="Transparency" />
-                <Choice Kind="ProcessNode" Name="Cutoff" />
-              </p:NodeReference>
-              <Pin Id="LIoPCgQ5WoAPJLy9ozEgV4" Name="Alpha" Kind="InputPin" />
-              <Pin Id="BhWMlGtzTiOLSEPCV7zo1d" Name="Enabled" Kind="InputPin" />
-              <Pin Id="BFEenl1tNpkNhPxrroyx4e" Name="Output" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="884,490,25,19" Id="Qy12cW1zDBJMRfQUKp6wjl">
-              <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="In" />
-              </p:NodeReference>
-              <Pin Id="CxbnipgLXWLMvOTzlg4a0R" Name="Value" Kind="InputPin" />
-              <Pin Id="HDAueqal9jfNI9dQoa5qRx" Name="Output" Kind="OutputPin" />
-            </Node>
-            <Pad Id="SRdLyVqGTZcPQcH8aFtjER" Bounds="1343,636,150,46" ShowValueBox="true" isIOBox="true" Value="needs to render in transparent stage">
-              <p:TypeAnnotation>
-                <Choice Kind="TypeFlag" Name="String" />
-              </p:TypeAnnotation>
-              <p:ValueBoxSettings>
-                <p:fontsize p:Type="Int32">9</p:fontsize>
-                <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
-              </p:ValueBoxSettings>
-            </Pad>
-            <Node Bounds="919,608,100,19" Id="GaEN7sKUX6cO6Un9nfuerf">
+            <Node Bounds="1149,785,105,19" Id="GaEN7sKUX6cO6Un9nfuerf">
               <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastSymbolSource="VL.Stride.Rendering.EffectShaderNodes">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessNode" Name="MyParticleProvider" />
               </p:NodeReference>
-              <Pin Id="KXpNFmnRdQENf0dwS3bkQG" Name="Value" Kind="InputPin" />
+              <Pin Id="GrHPlSO5UqwNWgtUsuCEQ7" Name="Vertex ID" Kind="InputPin" />
+              <Pin Id="B2FtDTjLwwxN67nPPVNbwM" Name="VID" Kind="InputPin" />
               <Pin Id="NeKsOrRxkdPLnQObTquhS4" Name="Particle Size" Kind="InputPin" />
               <Pin Id="TxkJhZbvAm7OjQmhSOVQvP" Name="Particles Buffer" Kind="InputPin" />
               <Pin Id="A5AsCsVrPAaMOYF0ESU2Ya" Name="Random Values" Kind="InputPin" />
               <Pin Id="KFU2c3HkDkRQFtWlRFYMcE" Name="P Norm" Kind="InputPin" />
               <Pin Id="EFfcoEBeJa6ME1SkP42T4t" Name="Output" Kind="OutputPin" />
             </Node>
-            <ControlPoint Id="AHC3Ei8VQbiPO8izVVE2Yu" Bounds="971,850" />
-            <Pad Id="BbFGwtGj64tPjdQhYSYbjw" Comment="Material Extension Name" Bounds="896,668,35,15" ShowValueBox="true" isIOBox="true" Value="SphereImpostorMaterialExtension">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="TypeFlag" Name="String" />
-              </p:TypeAnnotation>
-            </Pad>
+            <ControlPoint Id="AHC3Ei8VQbiPO8izVVE2Yu" Bounds="949,1025" />
+            <Node Bounds="1101,871,97,19" Id="C8qzpm594bxNHhSdAVHkDT">
+              <p:NodeReference LastCategoryFullName="Stride.Materials" LastSymbolSource="VL.Stride.Rendering.Nodes">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="ProcessAppFlag" Name="MaterialExtension" />
+                <CategoryReference Kind="Category" Name="Materials" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="P6TdFrkbdIWMou4AHIXjWD" Name="Material" Kind="InputPin" />
+              <Pin Id="FR95ssplrNTMXPDfePEekV" Name="Material Extension" Kind="InputPin" />
+              <Pin Id="K2vqrWR8oetN0ftRdeBdKU" Name="Vertex Addition" Kind="InputPin" />
+              <Pin Id="Jee4brCMVodOOE2rmMtDzm" Name="Pixel Addition" Kind="InputPin" />
+              <Pin Id="M8gzn68SXPTQZwN1Hy2CZZ" Name="Cutoff" Kind="InputPin" DefaultValue="True" />
+              <Pin Id="PQrAFS9mfAxP39Tc7DsswL" Name="Output" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="1150,826,88,19" Id="R9z7bd8fEsmK9XHX1Rl2Ge">
+              <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastSymbolSource="VL.Stride.Rendering.EffectShaderNodes">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="ProcessNode" Name="SphereImpostor" />
+              </p:NodeReference>
+              <Pin Id="NR9LF5MGKQPMRjEnDbKjUG" Name="Provider" Kind="InputPin" />
+              <Pin Id="D5yEx9wMSbwLfg7p5jrhOH" Name="Shading Color 0" Kind="InputPin" />
+              <Pin Id="QWFQm6dQzUaPr39IcFgw6w" Name="World" Kind="InputPin" />
+              <Pin Id="UaF7gUqy9JbL9rgzo4QaIu" Name="Output" Kind="OutputPin" />
+            </Node>
+            <ControlPoint Id="ViYrtI76WBYOMA15bE2sR1" Bounds="1063,610" />
           </Canvas>
           <ProcessDefinition Id="OV42zxvJSXrOcc7IF1pVEB">
             <Fragment Id="MBXzQIHc1eiPDYPqpy7Mee" Patch="CZFIDMWPYHJQbFewVCJQDo" Enabled="true" />
@@ -1037,19 +1000,10 @@
           <Link Id="DfczbuWfy0GLG8ILmSQ09G" Ids="Mo9dOBHLkwfOTsjIOyhCfj,CyTUsRI4E4OQHdv32sdaU2" />
           <Link Id="VnjqLuxaG1cMMmT5w2yULV" Ids="U8mO05nJJMsLi6T1mPkJTm,TrzxZWxkpj6NtcaSM7Xe3g" />
           <Link Id="NMAEf6QOtCIQFuG7wY58mk" Ids="KSi7j2G32eJMwinFyFD7Hn,D6E9GHJJAUEPpO7Na9Zl1Y" />
-          <Link Id="INDTv7m7PGuMQDSjd8tDQX" Ids="HEt5ZuIifJoPjet0sCKAnu,ODob4CbEUVXO8cmtLiMdtc" />
-          <Link Id="G0vHC4mNVQVPM67Jcd4Dtb" Ids="LSaRtghPTjtLxuMLOhjvO4,H9ery95rnInPYtxIoqnQKr" />
-          <Link Id="Azq0RrBOwtlNd4ThO3JWsY" Ids="Vqf9wuJmZoSLmOTeEr6NDc,MWcUCDEKHyBL2UILeODshN" />
-          <Link Id="M6s5NlGihNsNXJTOiBCisY" Ids="BFEenl1tNpkNhPxrroyx4e,UwXXgu6T7nfNbVcjxYicOH" />
-          <Link Id="I1L0W5Ny9XkLpU2LSq4AcY" Ids="AF0cvKe07jePmfoKZpjtvQ,CxbnipgLXWLMvOTzlg4a0R" />
-          <Link Id="LM9C0Yk4GsPNw0ynth9lKs" Ids="SIRNI7PSspkLAFJ4F0Nzgm,NpDbnRkBJogP8nV8adtwMr" />
-          <Link Id="A4ibjJcdrLBMBoEImYULWV" Ids="EFfcoEBeJa6ME1SkP42T4t,MBiode4s1cOMRZM5ZnPRSG" />
           <Link Id="Nmn3CBpzU6UQAPUMbgE4Be" Ids="KAnSujhgD1wPiLnXriVK1F,AHC3Ei8VQbiPO8izVVE2Yu" />
           <Link Id="JnTixJUIVgNLkWJb4NvZLa" Ids="AHC3Ei8VQbiPO8izVVE2Yu,QvJT4poD4GzOvaJ4Hz3dTV" IsHidden="true" />
-          <Link Id="HMZy4XoXFRtM9ixKdhLFhB" Ids="T8HWV3G7HJVLeLtbpxvYVi,EsWw5kSGiAQMoPCN5v3Av0" />
           <Link Id="RohH8hwakpyLX7lQViHQuV" Ids="OySo4puW8uhLZlTetVJw8i,TxkJhZbvAm7OjQmhSOVQvP" />
           <Link Id="TmtscuesYRIOiqNV5fET4n" Ids="QfYuwGUnBlBPtxW6YsUYUA,NeKsOrRxkdPLnQObTquhS4" />
-          <Link Id="DlAZfpJ3JhsPi3VvlqwpX0" Ids="HDAueqal9jfNI9dQoa5qRx,KXpNFmnRdQENf0dwS3bkQG" />
           <Patch Id="CZFIDMWPYHJQbFewVCJQDo" Name="Create" />
           <Patch Id="Meh3N0W5wsHOur708dOzQK" Name="Update">
             <Pin Id="D4kLwdH1ycLOMIeLtLuyhO" Name="Particles Buffer" Kind="InputPin" />
@@ -1068,7 +1022,14 @@
             <Pin Id="QvJT4poD4GzOvaJ4Hz3dTV" Name="Entity" Kind="OutputPin" Bounds="970,849" />
           </Patch>
           <Link Id="F7mLlgh0KD1L65yR8i4fVk" Ids="BMonosI7mIQL5iDL7qNnjW,DRZSdXSdrtkOU9YFfkwYlT" />
-          <Link Id="Njs3Qjs3dLJOfeckqPlwwg" Ids="BbFGwtGj64tPjdQhYSYbjw,LYcgsFkSjsFMFRhLt6CDpD" />
+          <Link Id="LokW9Tm7YGTNB178MCEdlX" Ids="SIRNI7PSspkLAFJ4F0Nzgm,P6TdFrkbdIWMou4AHIXjWD" />
+          <Link Id="NEJxaqYLcICPf7MrTxMHTR" Ids="PQrAFS9mfAxP39Tc7DsswL,NpDbnRkBJogP8nV8adtwMr" />
+          <Link Id="SAsieuhCaQ5NilPxlolBkM" Ids="UaF7gUqy9JbL9rgzo4QaIu,FR95ssplrNTMXPDfePEekV" />
+          <Link Id="HH1wLHtoEseONSjStjvKUR" Ids="EFfcoEBeJa6ME1SkP42T4t,NR9LF5MGKQPMRjEnDbKjUG" />
+          <Link Id="ApwJVZDyi70QMGirhJ6jPG" Ids="DeoHqRmxbuBLRFTPMyIAm4,ViYrtI76WBYOMA15bE2sR1" IsHidden="true" />
+          <Link Id="FJpYCPKWTFzLDETJHRsrzH" Ids="ViYrtI76WBYOMA15bE2sR1,TFtQ9hBOHvKLtoRMeUI1XV" />
+          <Link Id="ABe0DskfVF6NI89WV9Myo8" Ids="AF0cvKe07jePmfoKZpjtvQ,MBiode4s1cOMRZM5ZnPRSG" />
+          <Link Id="B1D6wRl5NPILJIPqVU5Ft7" Ids="LSaRtghPTjtLxuMLOhjvO4,MWcUCDEKHyBL2UILeODshN" />
         </Patch>
       </Node>
     </Canvas>
@@ -1089,7 +1050,7 @@
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SceneWindow" />
             </p:NodeReference>
-            <Pin Id="KB5Y8vreWQpLa79zg7iUUW" Name="Bounds" Kind="InputPin" DefaultValue="1125, 272, 648, 628">
+            <Pin Id="KB5Y8vreWQpLa79zg7iUUW" Name="Bounds" Kind="InputPin" DefaultValue="1124.8, 272, 648, 628">
               <p:TypeAnnotation LastCategoryFullName="2D" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Rectangle" />
               </p:TypeAnnotation>
@@ -1142,6 +1103,7 @@
             <Pin Id="BxsGzFyqCmgMSQh70PtOA9" Name="Initial Pitch" Kind="InputPin" />
             <Pin Id="J8DOWOxzWXoOmP5U3eQxbM" Name="Initial Distance" Kind="InputPin" />
             <Pin Id="DHjJ8leVagLNoEfDrpG7mz" Name="Initial Vertical Field Of View" Kind="InputPin" />
+            <Pin Id="MNSE44cv7MyPORLBQTxIsh" Name="Projection" Kind="InputPin" />
             <Pin Id="MTIInMya2HxOLwlAU3rJhO" Name="Near Clip Plane" Kind="InputPin" />
             <Pin Id="NPE78i1cdZWNMvJ4HHbmxI" Name="Far Clip Plane" Kind="InputPin" />
             <Pin Id="S8kElJ7GBXMLotqy2TJp5O" Name="Aspect Ratio" Kind="InputPin" />
@@ -1621,9 +1583,9 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="Dy0zFD8uTmYMzk069ST9sM" Location="VL.CoreLib" Version="2021.4.0-0310-gbc7bb47474" />
-  <NugetDependency Id="Lp16f7qHFemQFVwR2545bJ" Location="VL.Stride.Runtime" Version="2021.4.0-0325-g3b8548a925" />
+  <NugetDependency Id="Dy0zFD8uTmYMzk069ST9sM" Location="VL.CoreLib" Version="2021.4.0-0365-g698d9b47a2" />
+  <NugetDependency Id="Lp16f7qHFemQFVwR2545bJ" Location="VL.Stride.Runtime" Version="2021.4.0-0367-ge098dee0dd" />
   <PlatformDependency Id="Op16f7qHFemQFVwR2545bJ" Location="VL.Stride.Runtime.dll" />
-  <NugetDependency Id="IS68NBjN33xNudq4Meb8FU" Location="VL.EditingFramework" Version="2021.4.0-0310-gbc7bb47474" />
-  <NugetDependency Id="N2EmPdu0p2zMRRd7X1tgPt" Location="VL.Stride.Windows" Version="2021.4.0-0325-g3b8548a925" />
+  <NugetDependency Id="IS68NBjN33xNudq4Meb8FU" Location="VL.EditingFramework" Version="2021.4.0-0365-g698d9b47a2" />
+  <NugetDependency Id="N2EmPdu0p2zMRRd7X1tgPt" Location="VL.Stride.Windows" Version="2021.4.0-0367-ge098dee0dd" />
 </Document>

--- a/packages/VL.Stride.Runtime/help/Rendering/Example Geometry Shader with PBR.vl
+++ b/packages/VL.Stride.Runtime/help/Rendering/Example Geometry Shader with PBR.vl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="IZNEdmWwsqTPmRYNCw6rdu" LanguageVersion="2021.4.0.365" Version="0.128">
+<Document xmlns:p="property" Id="VUEgVjzaqBeO0H8alR0I7o" LanguageVersion="2021.4.0.365" Version="0.128">
   <NugetDependency Id="UMjQW1rcsHzLbQEEvmlyux" Location="VL.CoreLib" Version="2021.4.0-0365-g698d9b47a2" />
   <Patch Id="E3ImUTd2YNGObBvmdtwudp">
     <Canvas Id="UxUkpQTPbkoLBVXkPUqMgv" DefaultCategory="Main" CanvasType="FullCategory">
@@ -879,7 +879,7 @@
               </p:NodeReference>
               <Pin Id="Mo9dOBHLkwfOTsjIOyhCfj" Name="Output" Kind="OutputPin" />
             </Node>
-            <Node Bounds="836,727,85,19" Id="EezZJWR6KgmNrEgp63IU3m">
+            <Node Bounds="836,727,-12,19" Id="EezZJWR6KgmNrEgp63IU3m">
               <p:NodeReference LastCategoryFullName="Stride.Models.Meshes" LastSymbolSource="VL.Stride.Rendering.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="NullMesh" />
@@ -888,8 +888,6 @@
               <Pin Id="DRZSdXSdrtkOU9YFfkwYlT" Name="Count" Kind="InputPin" />
               <Pin Id="GiQEWWWFXQYNyiPt7CsfFf" Name="Topology" Kind="InputPin" />
               <Pin Id="OEuJG3IOvBfONZBflKSfte" Name="Bounding Box" Kind="InputPin" />
-              <Pin Id="LYcgsFkSjsFMFRhLt6CDpD" Name="Material Extension Name" Kind="InputPin" />
-              <Pin Id="F5YpTWgB91INxmRHuoXkT0" Name="Material Extension Shader" Kind="InputPin" />
               <Pin Id="U8mO05nJJMsLi6T1mPkJTm" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="948,963,165,19" Id="OOKIYjpKbILOfBMYmg8R5g">
@@ -941,21 +939,17 @@
               <Pin Id="QlESHeLYkX3NcPZROPceCZ" Name="Cull Mode" Kind="InputPin" />
               <Pin Id="SIRNI7PSspkLAFJ4F0Nzgm" Name="Output" Kind="OutputPin" />
             </Node>
-            <Node Bounds="1149,785,105,19" Id="GaEN7sKUX6cO6Un9nfuerf">
+            <Node Bounds="1147,794,105,19" Id="GaEN7sKUX6cO6Un9nfuerf">
               <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastSymbolSource="VL.Stride.Rendering.EffectShaderNodes">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessNode" Name="MyParticleProvider" />
               </p:NodeReference>
-              <Pin Id="GrHPlSO5UqwNWgtUsuCEQ7" Name="Vertex ID" Kind="InputPin" />
-              <Pin Id="B2FtDTjLwwxN67nPPVNbwM" Name="VID" Kind="InputPin" />
               <Pin Id="NeKsOrRxkdPLnQObTquhS4" Name="Particle Size" Kind="InputPin" />
               <Pin Id="TxkJhZbvAm7OjQmhSOVQvP" Name="Particles Buffer" Kind="InputPin" />
-              <Pin Id="A5AsCsVrPAaMOYF0ESU2Ya" Name="Random Values" Kind="InputPin" />
-              <Pin Id="KFU2c3HkDkRQFtWlRFYMcE" Name="P Norm" Kind="InputPin" />
               <Pin Id="EFfcoEBeJa6ME1SkP42T4t" Name="Output" Kind="OutputPin" />
             </Node>
             <ControlPoint Id="AHC3Ei8VQbiPO8izVVE2Yu" Bounds="949,1025" />
-            <Node Bounds="1101,871,97,19" Id="C8qzpm594bxNHhSdAVHkDT">
+            <Node Bounds="1101,871,44,19" Id="C8qzpm594bxNHhSdAVHkDT">
               <p:NodeReference LastCategoryFullName="Stride.Materials" LastSymbolSource="VL.Stride.Rendering.Nodes">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="MaterialExtension" />
@@ -963,12 +957,10 @@
               </p:NodeReference>
               <Pin Id="P6TdFrkbdIWMou4AHIXjWD" Name="Material" Kind="InputPin" />
               <Pin Id="FR95ssplrNTMXPDfePEekV" Name="Material Extension" Kind="InputPin" />
-              <Pin Id="K2vqrWR8oetN0ftRdeBdKU" Name="Vertex Addition" Kind="InputPin" />
-              <Pin Id="Jee4brCMVodOOE2rmMtDzm" Name="Pixel Addition" Kind="InputPin" />
               <Pin Id="M8gzn68SXPTQZwN1Hy2CZZ" Name="Cutoff" Kind="InputPin" DefaultValue="True" />
               <Pin Id="PQrAFS9mfAxP39Tc7DsswL" Name="Output" Kind="OutputPin" />
             </Node>
-            <Node Bounds="1150,826,88,19" Id="R9z7bd8fEsmK9XHX1Rl2Ge">
+            <Node Bounds="1147,835,88,19" Id="R9z7bd8fEsmK9XHX1Rl2Ge">
               <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastSymbolSource="VL.Stride.Rendering.EffectShaderNodes">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessNode" Name="SphereImpostor" />

--- a/packages/VL.Stride.Runtime/help/Rendering/shaders/MyParticleProvider_ShaderFX.sdsl
+++ b/packages/VL.Stride.Runtime/help/Rendering/shaders/MyParticleProvider_ShaderFX.sdsl
@@ -1,5 +1,15 @@
-shader MyParticleProvider_ShaderFX : ComputeFloat, ParticleProvider, ParticleStructPos4Vel4
+shader MyParticleProvider_ShaderFX : TransformationBase, ParticleProvider, ParticleStructPos4Vel4, ShaderBaseStream, Transformation, PositionStream4, NormalStream
 {
+    stage stream uint VertexID : SV_VertexID;
+    stage stream uint VID;
+
+    // override the vertex shader methods that handle position 
+    stage override void PreTransformPosition() 
+    {
+        streams.VID = streams.VertexID;
+        streams.PositionWS = streams.Position;
+    }
+
     cbuffer PerMaterial
     {
         stage float ParticleSize = 0.1;
@@ -10,8 +20,6 @@ shader MyParticleProvider_ShaderFX : ComputeFloat, ParticleProvider, ParticleStr
         stage StructuredBuffer<ParticlePos4Vel4> ParticlesBuffer;
         stage Buffer<float4> RandomValues;
     }
-
-    compose ComputeFloat Value;
 
     stage stream float4 pNorm;
     override stage float4 GetWorldPosition()
@@ -26,10 +34,5 @@ shader MyParticleProvider_ShaderFX : ComputeFloat, ParticleProvider, ParticleStr
     override stage float GetParticleSize()
     {
         return ParticleSize;
-    }
-
-    override float Compute()
-    {
-        return Value.Compute();
     }
 };

--- a/packages/VL.Stride.Runtime/help/Rendering/shaders/MyParticleProvider_ShaderFX.sdsl
+++ b/packages/VL.Stride.Runtime/help/Rendering/shaders/MyParticleProvider_ShaderFX.sdsl
@@ -1,15 +1,5 @@
 shader MyParticleProvider_ShaderFX : TransformationBase, ParticleProvider, ParticleStructPos4Vel4, ShaderBaseStream, Transformation, PositionStream4, NormalStream
 {
-    stage stream uint VertexID : SV_VertexID;
-    stage stream uint VID;
-
-    // override the vertex shader methods that handle position 
-    stage override void PreTransformPosition() 
-    {
-        streams.VID = streams.VertexID;
-        streams.PositionWS = streams.Position;
-    }
-
     cbuffer PerMaterial
     {
         stage float ParticleSize = 0.1;
@@ -18,16 +8,22 @@ shader MyParticleProvider_ShaderFX : TransformationBase, ParticleProvider, Parti
     rgroup PerMaterial
     {
         stage StructuredBuffer<ParticlePos4Vel4> ParticlesBuffer;
-        stage Buffer<float4> RandomValues;
     }
 
-    stage stream float4 pNorm;
+    stage stream uint VertexID : SV_VertexID;
+    stage stream uint VID;
+
+    // override the vertex shader methods that handle position 
+    stage override void PreTransformPosition()
+    {
+        streams.VID = streams.VertexID;
+        streams.PositionWS = streams.Position;
+    }
+
     override stage float4 GetWorldPosition()
     {
         uint id = streams.VID;
-        float4 Rnd = RandomValues[id];
         ParticlePos4Vel4 p = ParticlesBuffer[id];
-        streams.pNorm = p.Vel;
         return float4(p.Pos.xyz, 1);
     }
 

--- a/packages/VL.Stride.Runtime/help/Rendering/shaders/ParticleProvider.sdsl
+++ b/packages/VL.Stride.Runtime/help/Rendering/shaders/ParticleProvider.sdsl
@@ -1,11 +1,8 @@
-shader ParticleProvider : ShaderBaseStream, Transformation, PositionStream4, NormalStream, ShaderBase
+shader ParticleProvider
 {
-    stage stream uint VertexID : SV_VertexID;
-    stage stream uint VID;
-
     stage float4 GetWorldPosition()
     {
-        return mul(streams.Position, World);
+        return 1;
     }
 
     stage float GetParticleSize()

--- a/packages/VL.Stride.Runtime/help/Rendering/shaders/SphereImpostor_ShaderFX.sdsl
+++ b/packages/VL.Stride.Runtime/help/Rendering/shaders/SphereImpostor_ShaderFX.sdsl
@@ -1,6 +1,8 @@
 shader SphereImpostor_ShaderFX : Transformation, TransformationBase, PositionStream4, Texturing, ShadingBase, NormalStream, ShaderUtils
 {
 	compose ParticleProvider Provider;
+	
+	stage stream float PSize;
 
     // custom geometry shader, quad particle in this case
     [maxvertexcount(4)]
@@ -10,7 +12,7 @@ shader SphereImpostor_ShaderFX : Transformation, TransformationBase, PositionStr
 
         // get data from ParticleProvider implementation
         streams.PositionWS = Provider.GetWorldPosition();
-        float pSize = Provider.GetParticleSize();
+        streams.PSize = Provider.GetParticleSize();
 
         float padding = 1.5;
 		float2 offset;
@@ -19,7 +21,7 @@ shader SphereImpostor_ShaderFX : Transformation, TransformationBase, PositionStr
 		for (int i = 0; i<4; i++) 
 		{
 			streams.TexCoord = QuadPositions[i].xy * padding;
-			offset = sign(QuadPositions[i].xy) * pSize;
+			offset = sign(QuadPositions[i].xy) * streams.PSize;
 			float4 viewCornerPos = cameraSpherePos;
 			viewCornerPos.xy += offset * padding;
 			streams.ShadingPosition = mul(viewCornerPos, Projection);
@@ -58,7 +60,7 @@ shader SphereImpostor_ShaderFX : Transformation, TransformationBase, PositionStr
     //override shading, create sphere impostor in this case
     stage override float4 Shading() 
     {
-        float size = Provider.GetParticleSize();
+        float size = streams.PSize;
 
 		float3 worldPos, worldNormal;
 		sphereImpostor(streams.TexCoord, streams.PositionWS.xyz, size, worldPos, worldNormal);

--- a/packages/VL.Stride.Runtime/help/Rendering/shaders/SphereImpostor_ShaderFX.sdsl
+++ b/packages/VL.Stride.Runtime/help/Rendering/shaders/SphereImpostor_ShaderFX.sdsl
@@ -1,0 +1,77 @@
+shader SphereImpostor_ShaderFX : Transformation, TransformationBase, PositionStream4, Texturing, ShadingBase, NormalStream, ShaderUtils
+{
+	compose ParticleProvider Provider;
+
+    // custom geometry shader, quad particle in this case
+    [maxvertexcount(4)]
+    stage void GSMain(point Input input[1], inout TriangleStream<Output> triangleStream)
+    {
+        streams = input[0];
+
+        // get data from ParticleProvider implementation
+        streams.PositionWS = Provider.GetWorldPosition();
+        float pSize = Provider.GetParticleSize();
+
+        float padding = 1.5;
+		float2 offset;
+		float4 cameraSpherePos = mul(streams.PositionWS, WorldView);
+		
+		for (int i = 0; i<4; i++) 
+		{
+			streams.TexCoord = QuadPositions[i].xy * padding;
+			offset = sign(QuadPositions[i].xy) * pSize;
+			float4 viewCornerPos = cameraSpherePos;
+			viewCornerPos.xy += offset * padding;
+			streams.ShadingPosition = mul(viewCornerPos, Projection);
+
+			triangleStream.Append(streams);
+		}
+    }
+
+    void sphereImpostor(float2 screenCoord, float3 spherePos, float sphereRadius, out float3 pos, out float3 normal)
+	{
+		float3 cameraSpherePos = mul(float4(spherePos, 1), View).xyz;
+
+		float3 cameraPlanePos = float3(screenCoord * sphereRadius, 0.0) + cameraSpherePos;
+		float3 rayDirection = normalize(cameraPlanePos);
+	
+		float B = 2.0 * dot(rayDirection, -cameraSpherePos);
+		float C = dot(cameraSpherePos, cameraSpherePos) - (sphereRadius * sphereRadius);
+	
+		float det = (B * B) - (4 * C);
+		if(det < 0.0)
+			discard;
+		
+		float sqrtDet = sqrt(det);
+		float posT = (-B + sqrtDet)/2;
+		float negT = (-B - sqrtDet)/2;
+	
+		float intersectT = min(posT, negT);
+		pos = rayDirection * intersectT;
+		normal = normalize(pos - cameraSpherePos);
+
+		// back to world space
+		normal = normalize(mul(float4(normal, 0), ViewInverse).xyz);
+		pos = (normal * sphereRadius) + spherePos;
+	}
+
+    //override shading, create sphere impostor in this case
+    stage override float4 Shading() 
+    {
+        float size = Provider.GetParticleSize();
+
+		float3 worldPos, worldNormal;
+		sphereImpostor(streams.TexCoord, streams.PositionWS.xyz, size, worldPos, worldNormal);
+	
+        streams.PositionWS = float4(worldPos, 1);
+		streams.ShadingPosition = mul(streams.PositionWS, ViewProjection);
+
+		streams.DepthVS = streams.ShadingPosition.w;
+		streams.DepthLessEqual = streams.ShadingPosition.z/streams.ShadingPosition.w;
+
+		streams.normalWS = worldNormal;
+		streams.meshNormalWS = worldNormal;
+
+		return base.Shading();
+    }
+};

--- a/packages/VL.Stride.Runtime/src/Effects/TextureFX/Filters/ColorManipulation/Quantize_TextureFX.sdsl
+++ b/packages/VL.Stride.Runtime/src/Effects/TextureFX/Filters/ColorManipulation/Quantize_TextureFX.sdsl
@@ -7,7 +7,7 @@ shader Quantize_TextureFX : FilterBase
     uint Mode;
     bool QuantizeAlpha;
 
-    float4 Quantize(float4 col, float steps)
+    float4 Quant(float4 col, float steps)
     {
         switch (Mode)
         {
@@ -19,7 +19,7 @@ shader Quantize_TextureFX : FilterBase
 
     float4 Filter(float4 tex0col)
     {
-        float4 col = Quantize(tex0col, 1/StepSize);
+        float4 col = Quant(tex0col, 1/StepSize);
 
         if (!QuantizeAlpha)
             col.a = tex0col.a;

--- a/packages/VL.Stride.Runtime/src/Effects/Utils/CalcDispatchArgs_ComputeFX.sdsl.cs
+++ b/packages/VL.Stride.Runtime/src/Effects/Utils/CalcDispatchArgs_ComputeFX.sdsl.cs
@@ -20,6 +20,6 @@ namespace Stride.Rendering
     {
         public static readonly ObjectParameterKey<Buffer> CounterBuffer = ParameterKeys.NewObject<Buffer>();
         public static readonly ObjectParameterKey<Buffer> ArgsBuffer = ParameterKeys.NewObject<Buffer>();
-        public static readonly ValueParameterKey<Vector3> GroupSize = ParameterKeys.NewValue<Vector3>();
+        public static readonly ValueParameterKey<int> ThreadGroupSize = ParameterKeys.NewValue<int>(64);
     }
 }

--- a/packages/VL.Stride.Runtime/src/Effects/VLEffectMain.sdfx
+++ b/packages/VL.Stride.Runtime/src/Effects/VLEffectMain.sdfx
@@ -5,10 +5,13 @@ namespace VL.Stride.Rendering
 {
     params VLEffectParameters
     {
-        bool EnableExtensionName = false;
-        string MaterialExtensionName;
         bool EnableExtensionShader = false;
         ShaderSource MaterialExtensionShader;
+
+        bool EnableExtensionNameMesh = false;
+        string MaterialExtensionNameMesh;
+        bool EnableExtensionShaderMesh = false;
+        ShaderSource MaterialExtensionShaderMesh;
     
     }
 
@@ -18,14 +21,19 @@ namespace VL.Stride.Rendering
         
         mixin StrideForwardShadingEffect;
 
-        if (VLEffectParameters.EnableExtensionName)
-        {
-            mixin VLEffectParameters.MaterialExtensionName;
-        }
-
         if (VLEffectParameters.EnableExtensionShader)
         {
             mixin VLEffectParameters.MaterialExtensionShader;
+        }
+
+        if (VLEffectParameters.EnableExtensionNameMesh)
+        {
+            mixin VLEffectParameters.MaterialExtensionNameMesh;
+        }
+
+        if (VLEffectParameters.EnableExtensionShaderMesh)
+        {
+            mixin VLEffectParameters.MaterialExtensionShaderMesh;
         }
 
     };

--- a/packages/VL.Stride.Runtime/src/Effects/VLEffectMain.sdfx.cs
+++ b/packages/VL.Stride.Runtime/src/Effects/VLEffectMain.sdfx.cs
@@ -18,10 +18,12 @@ namespace VL.Stride.Rendering
 {
     [DataContract]public partial class VLEffectParameters : ShaderMixinParameters
     {
-        public static readonly PermutationParameterKey<bool> EnableExtensionName = ParameterKeys.NewPermutation<bool>(false);
-        public static readonly PermutationParameterKey<string> MaterialExtensionName = ParameterKeys.NewPermutation<string>();
         public static readonly PermutationParameterKey<bool> EnableExtensionShader = ParameterKeys.NewPermutation<bool>(false);
         public static readonly PermutationParameterKey<ShaderSource> MaterialExtensionShader = ParameterKeys.NewPermutation<ShaderSource>();
+        public static readonly PermutationParameterKey<bool> EnableExtensionNameMesh = ParameterKeys.NewPermutation<bool>(false);
+        public static readonly PermutationParameterKey<string> MaterialExtensionNameMesh = ParameterKeys.NewPermutation<string>();
+        public static readonly PermutationParameterKey<bool> EnableExtensionShaderMesh = ParameterKeys.NewPermutation<bool>(false);
+        public static readonly PermutationParameterKey<ShaderSource> MaterialExtensionShaderMesh = ParameterKeys.NewPermutation<ShaderSource>();
     };
     internal static partial class ShaderMixins
     {
@@ -30,13 +32,17 @@ namespace VL.Stride.Rendering
             public void Generate(ShaderMixinSource mixin, ShaderMixinContext context)
             {
                 context.Mixin(mixin, "StrideForwardShadingEffect");
-                if (context.GetParam(VLEffectParameters.EnableExtensionName))
-                {
-                    context.Mixin(mixin, context.GetParam(VLEffectParameters.MaterialExtensionName));
-                }
                 if (context.GetParam(VLEffectParameters.EnableExtensionShader))
                 {
                     context.Mixin(mixin, context.GetParam(VLEffectParameters.MaterialExtensionShader));
+                }
+                if (context.GetParam(VLEffectParameters.EnableExtensionNameMesh))
+                {
+                    context.Mixin(mixin, context.GetParam(VLEffectParameters.MaterialExtensionNameMesh));
+                }
+                if (context.GetParam(VLEffectParameters.EnableExtensionShaderMesh))
+                {
+                    context.Mixin(mixin, context.GetParam(VLEffectParameters.MaterialExtensionShaderMesh));
                 }
             }
 

--- a/packages/VL.Stride.Runtime/src/Rendering/Effects/EffectShaderNodes.ShaderFX.cs
+++ b/packages/VL.Stride.Runtime/src/Rendering/Effects/EffectShaderNodes.ShaderFX.cs
@@ -149,7 +149,11 @@ namespace VL.Stride.Rendering
                         inputs: comps);
 
                     nodeState.CurrentComputeNode = newComputeNode;
-                    nodeState.CurrentOutputValue = ShaderFXUtils.DeclAndSetVar(nodeState.ShaderName + "Result", newComputeNode);
+
+                    if (typeof(TInner) == typeof(VoidOrUnknown))
+                        nodeState.CurrentOutputValue = nodeState.CurrentComputeNode;
+                    else
+                        nodeState.CurrentOutputValue = ShaderFXUtils.DeclAndSetVar(nodeState.ShaderName + "Result", newComputeNode);
                 }
 
                 return (T)nodeState.CurrentOutputValue;

--- a/packages/VL.Stride.Runtime/src/Rendering/Effects/ParsedShader.cs
+++ b/packages/VL.Stride.Runtime/src/Rendering/Effects/ParsedShader.cs
@@ -57,7 +57,7 @@ namespace VL.Stride.Rendering
         {
             Shader = shader;
             ShaderClass = Shader.GetFirstClassDecl();
-            Variables = ShaderClass.Members.OfType<Variable>().ToList(); //should include parent shaders?
+            Variables = ShaderClass.Members.OfType<Variable>().Where(v => !v.Qualifiers.Contains(StrideStorageQualifier.Stream)).ToList(); //should include parent shaders?
             VariablesByName = Variables.ToDictionary(v => v.Name.Text);
             compositions = Variables
                 .Select((v, i) => (v, i))

--- a/packages/VL.Stride.Runtime/src/Rendering/Effects/ShaderMetadata.cs
+++ b/packages/VL.Stride.Runtime/src/Rendering/Effects/ShaderMetadata.cs
@@ -237,7 +237,7 @@ namespace VL.Stride.Rendering
 
         public Type GetShaderFXOutputType(out Type innerType)
         {
-            innerType = null;
+            innerType = typeof(VoidOrUnknown);
             foreach (var baseShader in ParsedShader?.BaseShaders ?? Enumerable.Empty<ParsedShader>())
             {
                 var baseName = baseShader?.ShaderClass?.Name;

--- a/packages/VL.Stride.Runtime/src/Rendering/Effects/ShaderMetadata.cs
+++ b/packages/VL.Stride.Runtime/src/Rendering/Effects/ShaderMetadata.cs
@@ -373,7 +373,7 @@ namespace VL.Stride.Rendering
                     }
 
                     //pins
-                    foreach (var pinDecl in shaderDecl.Members.OfType<Variable>().Where(v => !v.Qualifiers.Contains(StrideStorageQualifier.Compose)))
+                    foreach (var pinDecl in shaderDecl.Members.OfType<Variable>().Where(v => !v.Qualifiers.Contains(StrideStorageQualifier.Compose) && !v.Qualifiers.Contains(StrideStorageQualifier.Stream)))
                     {
                         foreach (var attr in pinDecl.Attributes.OfType<AttributeDeclaration>())
                         {

--- a/packages/VL.Stride.Runtime/src/Rendering/Materials/MaterialNodes.cs
+++ b/packages/VL.Stride.Runtime/src/Rendering/Materials/MaterialNodes.cs
@@ -122,10 +122,10 @@ namespace VL.Stride.Rendering.Materials
             yield return nodeFactory.NewNode(
                 name: "Material (Descriptor Internal)",
                 category: materialAdvancedCategory,
-                ctor: ctx => new MaterialBuilder_FromDescriptor(ctx),
+                ctor: ctx => new MaterialBuilderFromDescriptor(ctx),
                 copyOnWrite: false,
                 hasStateOutput: false)
-                .AddCachedInput(nameof(MaterialBuilder_FromDescriptor.Descriptor), x => x.Descriptor, (x, v) => x.Descriptor = v)
+                .AddCachedInput(nameof(MaterialBuilderFromDescriptor.Descriptor), x => x.Descriptor, (x, v) => x.Descriptor = v)
                 .AddCachedOutput("Output", x => x.ToMaterial());
 
             yield return nodeFactory.NewNode(
@@ -136,9 +136,9 @@ namespace VL.Stride.Rendering.Materials
                 hasStateOutput: false)
                 .AddOptimizedInput(nameof(MaterialBuilderFromMaterial.Material), x => x.Material, (x, v) => x.Material = v)
                 .AddOptimizedInput(nameof(MaterialBuilderFromMaterial.MaterialExtension), x => x.MaterialExtension, (x, v) => x.MaterialExtension = v)
-                .AddOptimizedInput(nameof(MaterialBuilderFromMaterial.VertexAddition), x => x.VertexAddition, (x, v) => x.VertexAddition = v)
-                .AddOptimizedInput(nameof(MaterialBuilderFromMaterial.PixelAddition), x => x.PixelAddition, (x, v) => x.PixelAddition = v)
-                .AddOptimizedInput(nameof(MaterialBuilderFromMaterial.Cutoff), x => x.Cutoff, (x, v) => x.Cutoff = v)
+                .AddOptimizedInput(nameof(MaterialBuilderFromMaterial.VertexAddition), x => x.VertexAddition, (x, v) => x.VertexAddition = v, isVisible: false, summary: "Connected shader must inherit from IMaterialSurface")
+                .AddOptimizedInput(nameof(MaterialBuilderFromMaterial.PixelAddition), x => x.PixelAddition, (x, v) => x.PixelAddition = v, isVisible: false, summary: "Connected shader must inherit from IMaterialSurface")
+                .AddOptimizedInput(nameof(MaterialBuilderFromMaterial.Cutoff), x => x.Cutoff, (x, v) => x.Cutoff = v, summary: "Sets the transparency feature of the material to Cutoff, needed when writing into depth in the pixel shader")
                 .AddCachedOutput("Output", x => x.ToMaterial());
         }
 
@@ -178,11 +178,11 @@ namespace VL.Stride.Rendering.Materials
     internal class MaterialBuilder : IDisposable
     {
         readonly MaterialAttributes @default = new MaterialAttributes();
-        readonly MaterialBuilder_FromDescriptor builder;
+        readonly MaterialBuilderFromDescriptor builder;
 
         public MaterialBuilder(NodeContext nodeContext)
         {
-            builder = new MaterialBuilder_FromDescriptor(nodeContext);
+            builder = new MaterialBuilderFromDescriptor(nodeContext);
         }
 
         public void Dispose()
@@ -247,12 +247,12 @@ namespace VL.Stride.Rendering.Materials
     /// <summary>
     /// A material defines the appearance of a 3D model surface and how it reacts to light.
     /// </summary>
-    internal class MaterialBuilder_FromDescriptor : IDisposable
+    internal class MaterialBuilderFromDescriptor : IDisposable
     {
         readonly IResourceHandle<Game> gameHandle;
         readonly SerialDisposable subscriptions = new SerialDisposable();
 
-        public MaterialBuilder_FromDescriptor(NodeContext nodeContext)
+        public MaterialBuilderFromDescriptor(NodeContext nodeContext)
         {
             gameHandle = nodeContext.GetGameHandle();
         }
@@ -282,11 +282,11 @@ namespace VL.Stride.Rendering.Materials
     /// </summary>
     internal class MaterialBuilderFromMaterial : IDisposable
     {
-        readonly MaterialBuilder_FromDescriptor builder;
+        readonly MaterialBuilderFromDescriptor builder;
 
         public MaterialBuilderFromMaterial(NodeContext nodeContext)
         {
-            builder = new MaterialBuilder_FromDescriptor(nodeContext);
+            builder = new MaterialBuilderFromDescriptor(nodeContext);
         }
 
         public void Dispose()

--- a/packages/VL.Stride.Runtime/src/Rendering/Materials/VLMaterialEmissiveFeature.cs
+++ b/packages/VL.Stride.Runtime/src/Rendering/Materials/VLMaterialEmissiveFeature.cs
@@ -1,0 +1,73 @@
+﻿using Stride.Core.Mathematics;
+using Stride.Rendering;
+using Stride.Rendering.Materials;
+using Stride.Shaders;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VL.Stride.Rendering.Materials
+{
+    public class VLMaterialEmissiveFeature : IMaterialEmissiveFeature
+    {
+        public IComputeNode VertexAddition { get; set; }
+
+        public IComputeNode PixelAddition { get; set; }
+
+        public IComputeNode MaterialExtension { get; set; }
+        
+        public IMaterialEmissiveFeature MaterialEmissiveFeature { get; set; }
+
+        public bool Enabled { get; set; } = true;
+
+        public bool Equals(IMaterialShadingModelFeature other)
+        {
+            return other is MaterialEmissiveMapFeature;
+        }
+
+        public void Visit(MaterialGeneratorContext context)
+        {
+            MaterialEmissiveFeature?.Visit(context);
+
+            if (Enabled && context.Step == MaterialGeneratorStep.GenerateShader)
+            {
+                AddMaterialExtension(context);
+
+                if (VertexAddition != null)
+                {
+                    AddVertexAddition(MaterialShaderStage.Vertex, context);
+                    //context.AddFinalCallback(MaterialShaderStage.Vertex, AddVertexAddition);
+                }
+
+                if (PixelAddition != null)
+                {
+                    AddPixelAddition(MaterialShaderStage.Pixel, context);
+                    //context.AddFinalCallback(MaterialShaderStage.Pixel, AddPixelAddition);
+                }
+            }
+        }
+
+        void AddMaterialExtension(MaterialGeneratorContext context)
+        {
+            var enableExtension = MaterialExtension != null;
+            context.Parameters.Set(VLEffectParameters.EnableExtensionShader, enableExtension);
+
+            if (enableExtension)
+                context.Parameters.Set(VLEffectParameters.MaterialExtensionShader, MaterialExtension.GenerateShaderSource(context, new MaterialComputeColorKeys(MaterialKeys.DiffuseMap, MaterialKeys.DiffuseValue, Color.White)));
+        }
+
+        void AddVertexAddition(MaterialShaderStage stage, MaterialGeneratorContext context)
+        {
+            var shaderSource = VertexAddition.GenerateShaderSource(context, new MaterialComputeColorKeys(MaterialKeys.DiffuseMap, MaterialKeys.DiffuseValue, Color.White));
+            context.AddShaderSource(MaterialShaderStage.Vertex, shaderSource);
+        }
+
+        void AddPixelAddition(MaterialShaderStage stage, MaterialGeneratorContext context)
+        {
+            var shaderSource = PixelAddition.GenerateShaderSource(context, new MaterialComputeColorKeys(MaterialKeys.DiffuseMap, MaterialKeys.DiffuseValue, Color.White));
+            context.AddShaderSource(MaterialShaderStage.Pixel, shaderSource);
+        }
+    }
+}

--- a/packages/VL.Stride.Runtime/src/Rendering/Materials/VLMaterialEmissiveFeature.cs
+++ b/packages/VL.Stride.Runtime/src/Rendering/Materials/VLMaterialEmissiveFeature.cs
@@ -52,10 +52,13 @@ namespace VL.Stride.Rendering.Materials
         void AddMaterialExtension(MaterialGeneratorContext context)
         {
             var enableExtension = MaterialExtension != null;
-            context.Parameters.Set(VLEffectParameters.EnableExtensionShader, enableExtension);
 
             if (enableExtension)
+            {
+                context.Parameters.Set(VLEffectParameters.EnableExtensionShader, enableExtension);
                 context.Parameters.Set(VLEffectParameters.MaterialExtensionShader, MaterialExtension.GenerateShaderSource(context, new MaterialComputeColorKeys(MaterialKeys.DiffuseMap, MaterialKeys.DiffuseValue, Color.White)));
+            }
+
         }
 
         void AddVertexAddition(MaterialShaderStage stage, MaterialGeneratorContext context)

--- a/packages/VL.Stride.Runtime/src/Rendering/Models/MeshExtensions.cs
+++ b/packages/VL.Stride.Runtime/src/Rendering/Models/MeshExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Reflection;
+using Stride.Core.Mathematics;
+using Stride.Rendering;
+
+namespace VL.Stride.Rendering
+{
+    public static class MeshExtensions
+    {
+        public static Mesh CloneWithNewParameters(this Mesh mesh)
+        {
+            var newMesh = new Mesh(mesh);
+            newMesh.ReplaceParameters();
+            return newMesh;
+        }
+
+        public static Mesh ReplaceParameters(this Mesh mesh)
+        {
+            var p = typeof(Mesh).GetProperty(nameof(Mesh.Parameters), BindingFlags.Public | BindingFlags.Instance);
+            p.SetValue(mesh, new ParameterCollection(mesh.Parameters));
+            return mesh;
+        }
+    }
+}

--- a/packages/VL.Stride.Runtime/src/Rendering/Models/ModelHelpers.cs
+++ b/packages/VL.Stride.Runtime/src/Rendering/Models/ModelHelpers.cs
@@ -1,10 +1,27 @@
 ﻿using System;
 using Stride.Core.Mathematics;
+using Stride.Rendering;
+using StrideModel = Stride.Rendering.Model;
 
 namespace VL.Stride.Rendering
 {
     public static class ModelHelpers
     {
+
+        public static StrideModel SetMeshParameter<T>(this StrideModel model, PermutationParameterKey<T> permutationParameter, T value)
+        {
+            var count = model?.Meshes?.Count;
+            if (count > 0)
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    model.Meshes[i]?.Parameters?.Set(permutationParameter, value);
+                }
+            }
+
+            return model;
+        }
+
         /// <summary>
         /// Calculates the vertex normals per triangle. If vertices are shared between triangles, they get an average normal weighted by face size.
         /// From: https://gamedev.stackexchange.com/questions/152991/how-can-i-calculate-normals-using-a-vertex-and-index-buffer

--- a/packages/VL.Stride.Runtime/src/Rendering/RenderFeatures/VLEffectRenderFeature.cs
+++ b/packages/VL.Stride.Runtime/src/Rendering/RenderFeatures/VLEffectRenderFeature.cs
@@ -38,15 +38,26 @@ namespace VL.Stride.Rendering
                         continue;
 
                     // Generate shader permuatations
-                    var enableByName = renderMesh.Mesh.Parameters.Get(VLEffectParameters.EnableExtensionName);
-                    renderEffect.EffectValidator.ValidateParameter(VLEffectParameters.EnableExtensionName, enableByName);
-                    if (enableByName)
-                        renderEffect.EffectValidator.ValidateParameter(VLEffectParameters.MaterialExtensionName, renderMesh.Mesh.Parameters.Get(VLEffectParameters.MaterialExtensionName));
-
                     var enableBySource = renderMesh.MaterialPass.Parameters.Get(VLEffectParameters.EnableExtensionShader);
-                    renderEffect.EffectValidator.ValidateParameter(VLEffectParameters.EnableExtensionShader, enableBySource);
                     if (enableBySource)
+                    {
+                        renderEffect.EffectValidator.ValidateParameter(VLEffectParameters.EnableExtensionShader, enableBySource);
                         renderEffect.EffectValidator.ValidateParameter(VLEffectParameters.MaterialExtensionShader, renderMesh.MaterialPass.Parameters.Get(VLEffectParameters.MaterialExtensionShader));
+                    }
+
+                    var enableByNameMesh = renderMesh.Mesh.Parameters.Get(VLEffectParameters.EnableExtensionNameMesh);
+                    if (enableByNameMesh)
+                    {
+                        renderEffect.EffectValidator.ValidateParameter(VLEffectParameters.EnableExtensionNameMesh, enableByNameMesh);
+                        renderEffect.EffectValidator.ValidateParameter(VLEffectParameters.MaterialExtensionNameMesh, renderMesh.Mesh.Parameters.Get(VLEffectParameters.MaterialExtensionNameMesh));
+                    }
+
+                    var enableBySourceMesh = renderMesh.Mesh.Parameters.Get(VLEffectParameters.EnableExtensionShaderMesh);
+                    if (enableBySourceMesh)
+                    {
+                        renderEffect.EffectValidator.ValidateParameter(VLEffectParameters.EnableExtensionShaderMesh, enableBySourceMesh);
+                        renderEffect.EffectValidator.ValidateParameter(VLEffectParameters.MaterialExtensionShaderMesh, renderMesh.Mesh.Parameters.Get(VLEffectParameters.MaterialExtensionShaderMesh));
+                    }
                 }
             }
         }

--- a/packages/VL.Stride.Runtime/src/Rendering/RenderFeatures/VLEffectRenderFeature.cs
+++ b/packages/VL.Stride.Runtime/src/Rendering/RenderFeatures/VLEffectRenderFeature.cs
@@ -43,10 +43,10 @@ namespace VL.Stride.Rendering
                     if (enableByName)
                         renderEffect.EffectValidator.ValidateParameter(VLEffectParameters.MaterialExtensionName, renderMesh.Mesh.Parameters.Get(VLEffectParameters.MaterialExtensionName));
 
-                    var enableBySource = renderMesh.Mesh.Parameters.Get(VLEffectParameters.EnableExtensionShader);
+                    var enableBySource = renderMesh.MaterialPass.Parameters.Get(VLEffectParameters.EnableExtensionShader);
                     renderEffect.EffectValidator.ValidateParameter(VLEffectParameters.EnableExtensionShader, enableBySource);
                     if (enableBySource)
-                        renderEffect.EffectValidator.ValidateParameter(VLEffectParameters.MaterialExtensionShader, renderMesh.Mesh.Parameters.Get(VLEffectParameters.MaterialExtensionShader));
+                        renderEffect.EffectValidator.ValidateParameter(VLEffectParameters.MaterialExtensionShader, renderMesh.MaterialPass.Parameters.Get(VLEffectParameters.MaterialExtensionShader));
                 }
             }
         }

--- a/packages/VL.Stride.Runtime/src/Shaders/ShaderFX/ShaderFXUtils.cs
+++ b/packages/VL.Stride.Runtime/src/Shaders/ShaderFX/ShaderFXUtils.cs
@@ -13,6 +13,11 @@ using Stride.Rendering;
 
 namespace VL.Stride.Shaders.ShaderFX
 {
+    /// <summary>
+    /// For ShaderFX nodes that dont compute a value or an unknown value
+    /// </summary>
+    public class VoidOrUnknown { }
+
     public static class ShaderFXUtils
     {
         public static GetVar<T> GetConstant<T>(T value)

--- a/packages/VL.Stride.Runtime/src/_NodeFactory_/CustomNode.cs
+++ b/packages/VL.Stride.Runtime/src/_NodeFactory_/CustomNode.cs
@@ -222,60 +222,65 @@ namespace VL.Stride
             return this;
         }
 
-        public CustomNodeDesc<TInstance> AddInput<T>(string name, Func<TInstance, T> getter, Action<TInstance, T> setter, T defaultValue, string summary = default, string remarks = default)
+        public CustomNodeDesc<TInstance> AddInput<T>(string name, Func<TInstance, T> getter, Action<TInstance, T> setter, T defaultValue, string summary = default, string remarks = default, bool isVisible = true)
         {
             inputs.Add(new CustomPinDesc(name, summary, remarks)
             {
                 Name = name.InsertSpaces(),
                 Type = typeof(T),
                 DefaultValue = defaultValue,
-                CreatePin = (node, instance) => new InputPin<T>(node, instance, getter, setter, defaultValue)
+                CreatePin = (node, instance) => new InputPin<T>(node, instance, getter, setter, defaultValue),
+                IsVisible = isVisible
             });
             return this;
         }
 
-        public CustomNodeDesc<TInstance> AddCachedInput<T>(string name, Func<TInstance, T> getter, Action<TInstance, T> setter, Func<T, T, bool> equals = default, string summary = default, string remarks = default)
+        public CustomNodeDesc<TInstance> AddCachedInput<T>(string name, Func<TInstance, T> getter, Action<TInstance, T> setter, Func<T, T, bool> equals = default, string summary = default, string remarks = default, bool isVisible = true)
         {
             inputs.Add(new CustomPinDesc(name, summary, remarks)
             {
                 Name = name.InsertSpaces(),
                 Type = typeof(T),
-                CreatePin = (node, instance) => new CachedInputPin<T>(node, instance, getter, setter, getter(instance), equals)
+                CreatePin = (node, instance) => new CachedInputPin<T>(node, instance, getter, setter, getter(instance), equals),
+                IsVisible = isVisible
             });
             return this;
         }
 
-        public CustomNodeDesc<TInstance> AddCachedInput<T>(string name, Func<TInstance, T> getter, Action<TInstance, T> setter, T defaultValue, string summary = default, string remarks = default)
-        {
-            inputs.Add(new CustomPinDesc(name, summary, remarks)
-            {
-                Name = name.InsertSpaces(),
-                Type = typeof(T),
-                DefaultValue = defaultValue,
-                CreatePin = (node, instance) => new CachedInputPin<T>(node, instance, getter, setter, defaultValue)
-            });
-            return this;
-        }
-
-        public CustomNodeDesc<TInstance> AddOptimizedInput<T>(string name, Func<TInstance, T> getter, Action<TInstance, T> setter, Func<T, T, bool> equals = default, string summary = default, string remarks = default)
-        {
-            inputs.Add(new CustomPinDesc(name, summary, remarks)
-            {
-                Name = name.InsertSpaces(),
-                Type = typeof(T),
-                CreatePin = (node, instance) => new OptimizedInputPin<T>(node, instance, getter, setter, getter(instance))
-            });
-            return this;
-        }
-
-        public CustomNodeDesc<TInstance> AddOptimizedInput<T>(string name, Func<TInstance, T> getter, Action<TInstance, T> setter, T defaultValue, string summary = default, string remarks = default)
+        public CustomNodeDesc<TInstance> AddCachedInput<T>(string name, Func<TInstance, T> getter, Action<TInstance, T> setter, T defaultValue, string summary = default, string remarks = default, bool isVisible = true)
         {
             inputs.Add(new CustomPinDesc(name, summary, remarks)
             {
                 Name = name.InsertSpaces(),
                 Type = typeof(T),
                 DefaultValue = defaultValue,
-                CreatePin = (node, instance) => new OptimizedInputPin<T>(node, instance, getter, setter, defaultValue)
+                CreatePin = (node, instance) => new CachedInputPin<T>(node, instance, getter, setter, defaultValue),
+                IsVisible = isVisible
+            });
+            return this;
+        }
+
+        public CustomNodeDesc<TInstance> AddOptimizedInput<T>(string name, Func<TInstance, T> getter, Action<TInstance, T> setter, Func<T, T, bool> equals = default, string summary = default, string remarks = default, bool isVisible = true)
+        {
+            inputs.Add(new CustomPinDesc(name, summary, remarks)
+            {
+                Name = name.InsertSpaces(),
+                Type = typeof(T),
+                CreatePin = (node, instance) => new OptimizedInputPin<T>(node, instance, getter, setter, getter(instance)),
+                IsVisible = isVisible
+            });
+            return this;
+        }
+
+        public CustomNodeDesc<TInstance> AddOptimizedInput<T>(string name, Func<TInstance, T> getter, Action<TInstance, T> setter, T defaultValue, string summary = default, string remarks = default, bool isVisible = true)
+        {
+            inputs.Add(new CustomPinDesc(name, summary, remarks)
+            {
+                Name = name.InsertSpaces(),
+                Type = typeof(T),
+                DefaultValue = defaultValue,
+                CreatePin = (node, instance) => new OptimizedInputPin<T>(node, instance, getter, setter, defaultValue),
+                IsVisible = isVisible
             });
             return this;
         }
@@ -395,7 +400,7 @@ namespace VL.Stride
             return this;
         }
 
-        class CustomPinDesc : IVLPinDescription, IInfo
+        class CustomPinDesc : IVLPinDescription, IInfo, IVLPinDescriptionWithVisibility
         {
             readonly string memberName;
             string summary;
@@ -419,6 +424,8 @@ namespace VL.Stride
             public string Summary => summary ?? (summary = typeof(TInstance).GetSummary(memberName));
 
             public string Remarks => remarks ?? (remarks = typeof(TInstance).GetRemarks(memberName));
+
+            public bool IsVisible { get; set; }
         }
 
         abstract class Pin : IVLPin


### PR DESCRIPTION
Simplifies the method of extending materials. only one node `MaterialExtension` is needed and any ShaderFX node can be connected to it. Since the input is a ShaderFX, a shader graph can be patched to extend the material.

Internally it creates a copy of the material descriptor, adds the additional shader source, and temporarily and builds a new material instance that is independent of the connected material. This allows re-using the same original material for multiple sinks.

![image](https://user-images.githubusercontent.com/1094716/132692103-e861f5e6-9281-4fe5-a20b-78e134681bc0.png)


